### PR TITLE
Add support for architectures in the wrappers

### DIFF
--- a/src/DockerRunner.jl
+++ b/src/DockerRunner.jl
@@ -84,7 +84,7 @@ function DockerRunner(workspace_root::String;
     envs = merge(platform_envs(platform, src_name; verbose=verbose), extra_env)
 
     # JIT out some compiler wrappers, add it to our mounts
-    generate_compiler_wrappers!(platform; bin_path=compiler_wrapper_path, extract_kwargs(kwargs, (:compilers,:allow_unsafe_flags))...)
+    generate_compiler_wrappers!(platform; bin_path=compiler_wrapper_path, extract_kwargs(kwargs, (:compilers,:allow_unsafe_flags,:lock_microarchitecture))...)
     push!(workspaces, compiler_wrapper_path => "/opt/bin")
 
     # the workspace_root is always a workspace, and we always mount it first

--- a/src/Platforms.jl
+++ b/src/Platforms.jl
@@ -92,7 +92,7 @@ end
 
 base_platform(p::Platform) = p
 base_platform(ep::ExtendedPlatform) = ep.p
-march(::Platform) = nothing
+march(::Platform; default=nothing) = default
 march(p::ExtendedPlatform; default = nothing) = get(p.ext, "march", default)
 
 for f in (:isapple, :islinux, :iswindows, :isbsd)

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -373,18 +373,22 @@ const available_llvm_builds = [
 ]
 
 """
-    gcc_version(cabi::CompilerABI, GCC_builds::Vector{GCCBuild})
+    gcc_version(p::Platform, , GCC_builds::Vector{GCCBuild})
 
-Returns the closest matching GCC version number for the given CompilerABI
-representing a particular platform, from the given set of options.  If no match
-is found, returns an empty list.  This method assumes that `cabi` represents a
-platform that binaries will be run on, and thus versions are always rounded
-down; e.g. if the platform supports a `libstdc++` version that corresponds to
-`GCC 5.1.0`, but the only GCC versions available to be picked from are `4.8.5`
-and `5.2.0`, it will return `4.8.5`, as binaries compiled with that version
-will run on this platform, whereas binaries compiled with `5.2.0` may not.
+Returns the closest matching GCC version number for the given particular
+platform, from the given set of options.  The compiler ABI and the
+microarchitecture of the platform will be taken into account.  If no match is
+found, returns an empty list.
+
+This method assumes that the compiler ABI of the platform represents a platform
+that binaries will be run on, and thus versions are always rounded down; e.g. if
+the platform supports a `libstdc++` version that corresponds to `GCC 5.1.0`, but
+the only GCC versions available to be picked from are `4.8.5` and `5.2.0`, it
+will return `4.8.5`, as binaries compiled with that version will run on this
+platform, whereas binaries compiled with `5.2.0` may not.
 """
-function gcc_version(cabi::CompilerABI, GCC_builds::Vector{GCCBuild})
+function gcc_version(p::Platform, GCC_builds::Vector{GCCBuild})
+    cabi = compiler_abi(p)
     # First, filter by libgfortran version.
     if libgfortran_version(cabi) !== nothing
         GCC_builds = filter(b -> libgfortran_version(getabi(b)) == libgfortran_version(cabi), GCC_builds)
@@ -407,6 +411,27 @@ function gcc_version(cabi::CompilerABI, GCC_builds::Vector{GCCBuild})
         GCC_builds = filter(b -> getversion(b) >= v"5", GCC_builds)
     end
 
+    # Filter the possible GCC versions depending on the microarchitecture
+    if march(p) !== nothing && march(p) in supported_marchs(p)
+        if march(p) in ("avx", "avx2")
+            # "sandybridge" and "haswell" introduced in GCC v4.9.0:
+            # https://www.gnu.org/software/gcc/gcc-4.9/changes.html
+            GCC_builds = filter(b -> getversion(b) >= v"4.9", GCC_builds)
+        elseif march(p) == "avx512"
+            # "skylake-avx512" introduced in GCC v6.1:
+            # https://www.gnu.org/software/gcc/gcc-6/changes.html
+            GCC_builds = filter(b -> getversion(b) >= v"6.1", GCC_builds)
+        elseif march(p) == "thunderx2"
+            # "thunderx2t99" introduced in GCC v7.1:
+            # https://www.gnu.org/software/gcc/gcc-7/changes.html
+            GCC_builds = filter(b -> getversion(b) >= v"7.1", GCC_builds)
+        elseif march(p) in ("neon", "vfp4", "carmel")
+            # "+aes" and "+sha2" extensions for aarch64 introduced in GCC v8:
+            # https://www.gnu.org/software/gcc/gcc-8/changes.html
+            GCC_builds = filter(b -> getversion(b) >= v"8.1", GCC_builds)
+        end
+    end
+
     return getversion.(GCC_builds)
 end
 
@@ -415,7 +440,7 @@ function select_gcc_version(p::Platform,
              preferred_gcc_version::VersionNumber = getversion(GCC_builds[1]),
          )
     # Determine which GCC build we're going to match with this CompilerABI:
-    GCC_builds = gcc_version(compiler_abi(p), GCC_builds)
+    GCC_builds = gcc_version(p, GCC_builds)
 
     if isempty(GCC_builds)
         error("Impossible CompilerABI constraints $(cabi)!")
@@ -586,7 +611,7 @@ replace_cxxstring_abi(ep::ExtendedPlatform, cxxstring_abi::Symbol) =
     expand_gfortran_versions(p::Platform)
 
 Given a `Platform`, returns an array of `Platforms` with a spread of identical
-entries with the exception of the `gcc_version` member of the `CompilerABI`
+entries with the exception of the `gfortran_version` member of the `CompilerABI`
 struct within the `Platform`.  This is used to take, for example, a list of
 supported platforms and expand them to include multiple GCC versions for
 the purposes of ABI matching.  If the given `Platform` already specifies a
@@ -648,10 +673,10 @@ julia> using BinaryBuilderBase
 
 julia> expand_marchs(FreeBSD(:x86_64))
 4-element Array{Platform,1}:
- ExtendedPlatform(FreeBSD(:x86_64); march="x86_64")
  ExtendedPlatform(FreeBSD(:x86_64); march="avx")
  ExtendedPlatform(FreeBSD(:x86_64); march="avx2")
  ExtendedPlatform(FreeBSD(:x86_64); march="avx512")
+ ExtendedPlatform(FreeBSD(:x86_64); march="x86_64")
 
 julia> expand_marchs(Linux(:armv7l))
 3-element Array{Platform,1}:
@@ -662,8 +687,8 @@ julia> expand_marchs(Linux(:armv7l))
 julia> expand_marchs(Linux(:aarch64))
 3-element Array{Platform,1}:
  ExtendedPlatform(Linux(:aarch64, libc=:glibc); march="armv8")
- ExtendedPlatform(Linux(:aarch64, libc=:glibc); march="thunderx2")
  ExtendedPlatform(Linux(:aarch64, libc=:glibc); march="carmel")
+ ExtendedPlatform(Linux(:aarch64, libc=:glibc); march="thunderx2")
 
 julia> expand_marchs(Windows(:i686))
 1-element Array{Windows,1}:
@@ -671,16 +696,13 @@ julia> expand_marchs(Windows(:i686))
 ```
 """
 function expand_marchs(p::Platform)
-    if p isa ExtendedPlatform && haskey(p.ext, "march")
+    if p isa ExtendedPlatform && march(p) !== nothing
+        # Nothing to expand if this has already a `march` entry
         return [p]
-    elseif arch(p) == :x86_64 && !isa(p, AnyPlatform)
-        # x86-64 (aka generic), avx (aka sandybridge), avx2 (aka haswell),
-        # avx512 (aka skylake-avx512 or skylakex)
-        return Platform[ExtendedPlatform(p; march=march) for march in ["x86_64", "avx", "avx2", "avx512"]]
-    elseif arch(p) == :armv7l
-        return Platform[ExtendedPlatform(p; march=march) for march in ["armv7l", "neon", "vfp4"]]
-    elseif arch(p) == :aarch64
-        return Platform[ExtendedPlatform(p; march=march) for march in ["armv8", "thunderx2", "carmel"]]
+    end
+    marchs = supported_marchs(p)
+    if length(marchs) > 0
+        return Platform[ExtendedPlatform(p; march=march) for march in marchs]
     else
         return [p]
     end
@@ -697,13 +719,13 @@ julia> using BinaryBuilderBase
 julia> expand_marchs(filter!(p -> p isa Linux && libc(p) == :glibc, supported_platforms()))
 12-element Array{Platform,1}:
  Linux(:i686, libc=:glibc)
- ExtendedPlatform(Linux(:x86_64, libc=:glibc); march="x86_64")
  ExtendedPlatform(Linux(:x86_64, libc=:glibc); march="avx")
  ExtendedPlatform(Linux(:x86_64, libc=:glibc); march="avx2")
  ExtendedPlatform(Linux(:x86_64, libc=:glibc); march="avx512")
+ ExtendedPlatform(Linux(:x86_64, libc=:glibc); march="x86_64")
  ExtendedPlatform(Linux(:aarch64, libc=:glibc); march="armv8")
- ExtendedPlatform(Linux(:aarch64, libc=:glibc); march="thunderx2")
  ExtendedPlatform(Linux(:aarch64, libc=:glibc); march="carmel")
+ ExtendedPlatform(Linux(:aarch64, libc=:glibc); march="thunderx2")
  ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf); march="armv7l")
  ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf); march="neon")
  ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf); march="vfp4")

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -412,7 +412,7 @@ function gcc_version(p::Platform, GCC_builds::Vector{GCCBuild})
     end
 
     # Filter the possible GCC versions depending on the microarchitecture
-    if march(p) !== nothing && march(p) in supported_marchs(p)
+    if march(p) !== nothing
         if march(p) in ("avx", "avx2")
             # "sandybridge" and "haswell" introduced in GCC v4.9.0:
             # https://www.gnu.org/software/gcc/gcc-4.9/changes.html

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -1,6 +1,30 @@
 import Base: strip
 abstract type Runner; end
 
+const ARCHITECTURE_FLAGS = begin
+    # Better be always explicit about `-march` & `-mtune`:
+    # https://lemire.me/blog/2018/07/25/it-is-more-complicated-than-i-thought-mtune-march-in-gcc/
+    march_flags(arch) = ["-m$(f)=$(arch)" for f in ("arch", "tune")]
+    Dict(
+        :x86_64 => Dict(
+            "x86_64" => march_flags("x86-64"),
+            "avx" => march_flags("sandybridge"),
+            "avx2" => march_flags("haswell"),
+            "avx512" => march_flags("skylake-avx512"),
+        ),
+        :armv7l => Dict(
+            "armv7l" => ["-march=armv7-a", "-mtune=generic-armv7-a"],
+            "neon" => ["-march=armv7-a+neon", "-mtune=generic-armv7-a"],
+            "vfp4" => ["-march=armv7-a+neon-vfpv4", "-mtune=generic-armv7-a"],
+        ),
+        :aarch64 => Dict(
+            "armv8" => ["-march=armv8-a", "-mtune=cortex-a57"],
+            "thunderx2" => ["-march=armv8.1-a", "-mtune=thunderx2t99"],
+            "carmel" => ["-march=armv8.2-a+crypto+fp16+sha2+aes", "-mtune=cortex-a75"],
+        ),
+    )
+end
+
 function nbits(p::Platform)
     if arch(p) in (:i686, :armv7l)
         return 32
@@ -23,13 +47,31 @@ function proc_family(p::Platform)
     end
 end
 
+function supported_marchs(p::Platform)
+    this_march = march(p)
+    if p isa ExtendedPlatform && this_march !== nothing
+        if this_march in keys(ARCHITECTURE_FLAGS[arch(p)])
+            return [this_march]
+        else
+            String[]
+        end
+    elseif !isa(p, AnyPlatform) && arch(p) in keys(ARCHITECTURE_FLAGS)
+        # Sort they entries, for deterministic output
+        return sort(collect(keys(ARCHITECTURE_FLAGS[arch(p)])))
+    else
+        return String[]
+    end
+end
+
 dlext(p::Windows) = "dll"
 dlext(p::MacOS) = "dylib"
 dlext(p::Union{Linux,FreeBSD}) = "so"
+dlext(p::ExtendedPlatform) = dlext(p.p)
 dlext(p::Platform) = error("Unknown dlext for platform $(p)")
 
 exeext(p::Windows) = ".exe"
 exeext(p::Union{Linux,FreeBSD,MacOS}) = ""
+exeext(p::ExtendedPlatform) = exeext(p.p)
 exeext(p::Platform) = error("Unknown exeext for platform $(p)")
 
 # Convert platform to a triplet, but strip out the ABI parts.
@@ -108,7 +150,8 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
                      compile_only_flags::Vector = String[],
                      link_only_flags::Vector = String[],
                      env::Dict{String,String} = Dict{String,String}(),
-                     unsafe_flags = String[])
+                     unsafe_flags = String[],
+                     no_marchs::Bool = true)
         write(io, """
         #!/bin/bash
         # This compiler wrapper script brought into existence by `generate_compiler_wrappers!()`
@@ -159,6 +202,17 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
 
         for (name, val) in env
             write(io, "export $(name)=\"$(val)\"\n")
+        end
+
+        # TODO: improve this check
+        if no_marchs
+            write(io, raw"""
+                      if [[ \"$@\" == *\"-march=\"* ]]; then
+                          echo \"Cannot force an architecture\" >&2
+                          exit 1
+                      fi
+                      """)
+            println(io)
         end
 
         if length(unsafe_flags) >= 1
@@ -235,6 +289,15 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
         return FLAGS
     end
 
+    function march_flags(p::Platform)
+        # This is an extended platform, which specifies an architecture which we do support
+        if platform isa ExtendedPlatform && length(supported_marchs(platform)) > 0 && march(platform) in supported_marchs(platform)
+            return ARCHITECTURE_FLAGS[arch(platform)][march(platform)]
+        else
+            return String[]
+        end
+    end
+
     clang_targeting_laser(p::Platform) = "-target $(aatriplet(p)) --sysroot=/opt/$(aatriplet(p))/$(aatriplet(p))/sys-root"
     # For MacOS and FreeBSD, we don't set `-rtlib`, and FreeBSD is special-cased within the LLVM source tree
     # to not allow for -gcc-toolchain, which means that we have to manually add the location of libgcc_s.  LE SIGH.
@@ -242,12 +305,12 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
     # https://github.com/llvm-mirror/clang/blob/f3b7928366f63b51ffc97e74f8afcff497c57e8d/lib/Driver/ToolChains/FreeBSD.cpp
     clang_flags(p::Union{FreeBSD,MacOS}) = clang_targeting_laser(p)
 
-    clang_compile_flags(p::Platform) = String[]
+    clang_compile_flags(p::Platform) = march_flags(p)
     # Next, on MacOS, we need to override the typical C++ include search paths, because it always includes
     # the toolchain C++ headers first.  Valentin tracked this down to:
     # https://github.com/llvm/llvm-project/blob/0378f3a90341d990236c44f297b923a32b35fab1/clang/lib/Driver/ToolChains/Darwin.cpp#L1944-L1978
     # We also add `-Wno-unused-command-line-argument` so that if someone does something like `clang -Werror -o foo a.o b.o`, it doesn't complain.
-    clang_compile_flags(p::MacOS) = String["-Wno-unused-command-line-argument", "-nostdinc++", "-isystem", "/opt/$(aatriplet(p))/$(aatriplet(p))/sys-root/usr/include/c++/v1"]
+    clang_compile_flags(p::MacOS) = vcat(march_flags(p), String["-Wno-unused-command-line-argument", "-nostdinc++", "-isystem", "/opt/$(aatriplet(p))/$(aatriplet(p))/sys-root/usr/include/c++/v1"])
 
     # For everything else, there's MasterCard (TM) (.... also, we need to provide `-rtlib=libgcc` because clang-builtins are broken,
     # and we also need to provide `-stdlib=libstdc++` to match Julia on these platforms.)
@@ -271,9 +334,9 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
     gfortran_link_flags(p::Platform) = gcc_link_flags(p)
 
     # C/C++/Fortran
-    gcc(io::IO, p::Platform)      = wrapper(io, "/opt/$(aatriplet(p))/bin/$(aatriplet(p))-gcc $(gcc_flags(p))"; hash_args=true, link_only_flags=gcc_link_flags(p), unsafe_flags = allow_unsafe_flags ? String[] : ["-Ofast", "-ffast-math", "-funsafe-math-optimizations"])
-    gxx(io::IO, p::Platform)      = wrapper(io, "/opt/$(aatriplet(p))/bin/$(aatriplet(p))-g++ $(gcc_flags(p))"; hash_args=true, link_only_flags=gcc_link_flags(p), unsafe_flags = allow_unsafe_flags ? String[] : ["-Ofast", "-ffast-math", "-funsafe-math-optimizations"])
-    gfortran(io::IO, p::Platform) = wrapper(io, "/opt/$(aatriplet(p))/bin/$(aatriplet(p))-gfortran $(fortran_flags(p))"; allow_ccache=false, link_only_flags=gfortran_link_flags(p), unsafe_flags = allow_unsafe_flags ? String[] : ["-Ofast", "-ffast-math", "-funsafe-math-optimizations"])
+    gcc(io::IO, p::Platform)      = wrapper(io, "/opt/$(aatriplet(p))/bin/$(aatriplet(p))-gcc $(gcc_flags(p))"; hash_args=true, compile_only_flags=march_flags(p), link_only_flags=gcc_link_flags(p), unsafe_flags = allow_unsafe_flags ? String[] : ["-Ofast", "-ffast-math", "-funsafe-math-optimizations"])
+    gxx(io::IO, p::Platform)      = wrapper(io, "/opt/$(aatriplet(p))/bin/$(aatriplet(p))-g++ $(gcc_flags(p))"; hash_args=true, compile_only_flags=march_flags(p), link_only_flags=gcc_link_flags(p), unsafe_flags = allow_unsafe_flags ? String[] : ["-Ofast", "-ffast-math", "-funsafe-math-optimizations"])
+    gfortran(io::IO, p::Platform) = wrapper(io, "/opt/$(aatriplet(p))/bin/$(aatriplet(p))-gfortran $(fortran_flags(p))"; allow_ccache=false, compile_only_flags=march_flags(p), link_only_flags=gfortran_link_flags(p), unsafe_flags = allow_unsafe_flags ? String[] : ["-Ofast", "-ffast-math", "-funsafe-math-optimizations"])
     clang(io::IO, p::Platform)    = wrapper(io, "/opt/$(host_target)/bin/clang $(clang_flags(p))"; compile_only_flags=clang_compile_flags(p), link_only_flags=clang_link_flags(p))
     clangxx(io::IO, p::Platform)  = wrapper(io, "/opt/$(host_target)/bin/clang++ $(clang_flags(p))"; compile_only_flags=clang_compile_flags(p), link_only_flags=clang_link_flags(p))
     objc(io::IO, p::Platform)     = wrapper(io, "/opt/$(host_target)/bin/clang -x objective-c $(clang_flags(p))"; compile_only_flags=clang_compile_flags(p), link_only_flags=clang_link_flags(p))

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -28,7 +28,7 @@ function supported_marchs(p::Platform)
     if p isa ExtendedPlatform && this_march !== nothing
         return [this_march]
     elseif !isa(p, AnyPlatform) && arch(p) in keys(ARCHITECTURE_FLAGS)
-        # Sort they entries, for deterministic output
+        # Sort the entries, for deterministic output
         return sort(collect(keys(ARCHITECTURE_FLAGS[arch(p)])))
     else
         return String[]
@@ -123,7 +123,7 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
                      link_only_flags::Vector = String[],
                      env::Dict{String,String} = Dict{String,String}(),
                      unsafe_flags = String[],
-                     no_marchs::Bool = true)
+                     lock_microarchitecture::Bool = true)
         write(io, """
         #!/bin/bash
         # This compiler wrapper script brought into existence by `generate_compiler_wrappers!()`
@@ -177,7 +177,7 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
         end
 
         # TODO: improve this check
-        if no_marchs
+        if lock_microarchitecture
             write(io, raw"""
                       if [[ \"$@\" == *\"-march=\"* ]]; then
                           echo \"Cannot force an architecture\" >&2

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -42,7 +42,7 @@ function UserNSRunner(workspace_root::String;
     envs = merge(platform_envs(platform, src_name; verbose=verbose), extra_env)
 
     # JIT out some compiler wrappers, add it to our mounts
-    generate_compiler_wrappers!(platform; bin_path=compiler_wrapper_path, extract_kwargs(kwargs, (:compilers,:allow_unsafe_flags))...)
+    generate_compiler_wrappers!(platform; bin_path=compiler_wrapper_path, extract_kwargs(kwargs, (:compilers,:allow_unsafe_flags,:lock_microarchitecture))...)
     push!(workspaces, compiler_wrapper_path => "/opt/bin")
 
     # the workspace_root is always a workspace, and we always mount it first

--- a/test/platforms.jl
+++ b/test/platforms.jl
@@ -130,6 +130,9 @@ end
     Artifacts.pack_platform!(meta, p)
     @test meta == Dict("arch" => "armv7l","libc" => "glibc","march" => "armv7l","libstdcxx_version" => "3.4.24","os" => "linux")
 
+    # Extended platform with wrong microarchitecture
+    @test_throws ArgumentError ExtendedPlatform(Linux(:x86_64); march="carmel")
+
     # Parse `"any"` as `AnyPlatform`
     @test tryparse(ExtendedPlatform, "any") == AnyPlatform()
     # AnyPlatform shouldn't be extended

--- a/test/platforms.jl
+++ b/test/platforms.jl
@@ -1,7 +1,7 @@
 using Test
-using Pkg, Pkg.PlatformEngines, Pkg.BinaryPlatforms
+using Pkg, Pkg.PlatformEngines, Pkg.BinaryPlatforms, Pkg.Artifacts
 using BinaryBuilderBase
-using BinaryBuilderBase: abi_agnostic, get_concrete_platform
+using BinaryBuilderBase: abi_agnostic, get_concrete_platform, march
 
 @testset "Supported Platforms" begin
     all = supported_platforms()
@@ -19,32 +19,36 @@ using BinaryBuilderBase: abi_agnostic, get_concrete_platform
 end
 
 @testset "ExtendedPlatform" begin
-    p = ExtendedPlatform(Linux(:x86_64; libc=:musl); microarchitecture = :avx, cuda = "9.2")
+    p = ExtendedPlatform(Linux(:x86_64; libc=:musl); march = "avx", cuda = "9.2")
     @test p.p == Linux(:x86_64, libc=:musl)
-    @test p.ext == Dict("microarchitecture" => "avx", "cuda" => "9.2")
+    @test p.ext == Dict("march" => "avx", "cuda" => "9.2")
     @test BinaryPlatforms.platform_name(p) == "ExtendedPlatform"
     @test BinaryPlatforms.arch(p) == :x86_64
     @test BinaryPlatforms.libc(p) == :musl
     @test BinaryPlatforms.call_abi(p) == nothing
     @test BinaryPlatforms.compiler_abi(p) == CompilerABI()
-    @test BinaryPlatforms.triplet(p) == "x86_64-linux-musl-cuda+9.2-microarchitecture+avx"
+    @test BinaryPlatforms.triplet(p) == "x86_64-linux-musl-cuda+9.2-march+avx"
     @test abi_agnostic(p) == Linux(:x86_64, libc=:musl)
     @test aatriplet(p) == "x86_64-linux-musl"
-    @test replace_cxxstring_abi(p, :cxx03) == ExtendedPlatform(Linux(:x86_64; libc=:musl, compiler_abi=CompilerABI(; cxxstring_abi=:cxx03)); microarchitecture = :avx, cuda = "9.2")
-    @test replace_libgfortran_version(p, v"4") == ExtendedPlatform(Linux(:x86_64; libc=:musl, compiler_abi=CompilerABI(; libgfortran_version=v"4")); microarchitecture = :avx, cuda = "9.2")
-    @test get_concrete_platform(p; compilers = [:c], preferred_gcc_version = v"4.8", preferred_llvm_version = v"9") == ExtendedPlatform(Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3", cxxstring_abi=:cxx03)); microarchitecture="avx", cuda="9.2")
-    @test ExtendedPlatform(p; cuda="9.2", foo="bar") == ExtendedPlatform(Linux(:x86_64, libc=:musl); microarchitecture="avx", cuda="9.2", foo="bar")
-    @test ExtendedPlatform(p; foo="bar") == ExtendedPlatform(Linux(:x86_64, libc=:musl); microarchitecture="avx", cuda="9.2", foo="bar")
+    @test replace_cxxstring_abi(p, :cxx03) == ExtendedPlatform(Linux(:x86_64; libc=:musl, compiler_abi=CompilerABI(; cxxstring_abi=:cxx03)); march = "avx", cuda = "9.2")
+    @test replace_libgfortran_version(p, v"4") == ExtendedPlatform(Linux(:x86_64; libc=:musl, compiler_abi=CompilerABI(; libgfortran_version=v"4")); march = "avx", cuda = "9.2")
+    # The concrete platform has C++11 strinb ABI because march=avx requires GCC v5
+    @test get_concrete_platform(p; compilers = [:c], preferred_gcc_version = v"4.8", preferred_llvm_version = v"9") == ExtendedPlatform(Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3", cxxstring_abi=:cxx11)); march="avx", cuda="9.2")
+    @test ExtendedPlatform(p; cuda="9.2", foo="bar") == ExtendedPlatform(Linux(:x86_64, libc=:musl); march="avx", cuda="9.2", foo="bar")
+    @test ExtendedPlatform(p; foo="bar") == ExtendedPlatform(Linux(:x86_64, libc=:musl); march="avx", cuda="9.2", foo="bar")
     @test_throws ErrorException ExtendedPlatform(p; cuda="10.1")
     # We have to split in this way the test on the representation of the type
     # because it may depend on the order with which the keys are extracted from
     # the dictionary
     @test startswith(repr(p), "ExtendedPlatform(Linux(:x86_64, libc=:musl);")
-    @test occursin("microarchitecture=\"avx\"", repr(p))
+    @test occursin("march=\"avx\"", repr(p))
     @test occursin("cuda=\"9.2\"", repr(p))
     @test endswith(repr(p), ")")
     # Make sure the round trip works
     @test parse(ExtendedPlatform, triplet(p)) == p
+    meta = Dict{String,String}()
+    Artifacts.pack_platform!(meta, p)
+    @test meta == Dict("arch" => "x86_64","libc" => "musl","march" => "avx","os" => "linux")
 
     p = ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx03)); microarchitecture="skylake_avx512", cuda="10.1", cuda_capability="52")
     @test p.p == Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx03))
@@ -69,6 +73,9 @@ end
     @test occursin("cuda_capability=\"52\"", repr(p))
     @test endswith(repr(p), ")")
     @test parse(ExtendedPlatform, triplet(p)) == p
+    meta = Dict{String,String}()
+    Artifacts.pack_platform!(meta, p)
+    @test meta == Dict("libgfortran_version" => "5.0.0","arch" => "powerpc64le","libc" => "glibc","os" => "linux","cxxstring_abi" => "cxx03")
 
     p = ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx11)); microarchitecture="skylake_avx512", cuda="10.1", cuda_capability="52")
     @test p.p == Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx11))
@@ -93,29 +100,35 @@ end
     @test occursin("cuda_capability=\"52\"", repr(p))
     @test endswith(repr(p), ")")
     @test parse(ExtendedPlatform, triplet(p)) == p
+    meta = Dict{String,String}()
+    Artifacts.pack_platform!(meta, p)
+    @test meta == Dict("libgfortran_version" => "5.0.0","arch" => "powerpc64le","libc" => "glibc","os" => "linux","cxxstring_abi" => "cxx11")
 
-    p = ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(; libstdcxx_version=v"3.4.24")); microarchitecture="sandybridge", cuda="11.1")
+    p = ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(; libstdcxx_version=v"3.4.24")); march="armv7l", cuda="11.1")
     @test p.p == Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(; libstdcxx_version=v"3.4.24"))
-    @test p.ext == Dict("microarchitecture" => "sandybridge","cuda" => "11.1")
+    @test p.ext == Dict("march" => "armv7l","cuda" => "11.1")
     @test BinaryPlatforms.platform_name(p) == "ExtendedPlatform"
     @test BinaryPlatforms.arch(p) == :armv7l
     @test BinaryPlatforms.libc(p) == :glibc
     @test BinaryPlatforms.call_abi(p) == :eabihf
     @test BinaryPlatforms.compiler_abi(p) == CompilerABI(libstdcxx_version=v"3.4.24")
-    @test occursin(r"^arm(v7l)?-linux-gnueabihf-libstdcxx24-cuda\+11.1-microarchitecture\+sandybridge$", BinaryPlatforms.triplet(p))
+    @test occursin(r"^arm(v7l)?-linux-gnueabihf-libstdcxx24-cuda\+11.1-march\+armv7l$", BinaryPlatforms.triplet(p))
     @test abi_agnostic(p) == Linux(:armv7l, libc=:glibc, call_abi=:eabihf)
     @test aatriplet(p) == "arm-linux-gnueabihf"
-    @test replace_cxxstring_abi(p, :cxx11) == ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(; cxxstring_abi=:cxx11, libstdcxx_version=v"3.4.24")); microarchitecture="sandybridge", cuda="11.1")
-    @test replace_libgfortran_version(p, v"4") == ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(; libgfortran_version=v"4", libstdcxx_version=v"3.4.24")); microarchitecture="sandybridge", cuda="11.1")
-    @test get_concrete_platform(p; compilers = [:c], preferred_gcc_version = v"7", preferred_llvm_version = v"9") == ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0", libstdcxx_version=v"3.4.24", cxxstring_abi=:cxx11)); microarchitecture="sandybridge", cuda="11.1")
-    @test ExtendedPlatform(p; cuda="11.1", foo="bar") == ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libstdcxx_version=v"3.4.24")); microarchitecture="sandybridge", cuda="11.1", foo="bar")
-    @test ExtendedPlatform(p; foo="bar") == ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libstdcxx_version=v"3.4.24")); microarchitecture="sandybridge", cuda="11.1", foo="bar")
-    @test_throws ErrorException ExtendedPlatform(p; cuda="11.1", microarchitecture="haswell")
+    @test replace_cxxstring_abi(p, :cxx11) == ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(; cxxstring_abi=:cxx11, libstdcxx_version=v"3.4.24")); march="armv7l", cuda="11.1")
+    @test replace_libgfortran_version(p, v"4") == ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(; libgfortran_version=v"4", libstdcxx_version=v"3.4.24")); march="armv7l", cuda="11.1")
+    @test get_concrete_platform(p; compilers = [:c], preferred_gcc_version = v"7", preferred_llvm_version = v"9") == ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0", libstdcxx_version=v"3.4.24", cxxstring_abi=:cxx11)); march="armv7l", cuda="11.1")
+    @test ExtendedPlatform(p; cuda="11.1", foo="bar") == ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libstdcxx_version=v"3.4.24")); march="armv7l", cuda="11.1", foo="bar")
+    @test ExtendedPlatform(p; foo="bar") == ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libstdcxx_version=v"3.4.24")); march="armv7l", cuda="11.1", foo="bar")
+    @test_throws ErrorException ExtendedPlatform(p; cuda="11.1", march="neon")
     @test startswith(repr(p), "ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libstdcxx_version=v\"3.4.24\")); ")
-    @test occursin("microarchitecture=\"sandybridge\"", repr(p))
+    @test occursin("march=\"armv7l\"", repr(p))
     @test occursin("cuda=\"11.1\"", repr(p))
     @test endswith(repr(p), ")")
     @test parse(ExtendedPlatform, triplet(p)) == p
+    meta = Dict{String,String}()
+    Artifacts.pack_platform!(meta, p)
+    @test meta == Dict("arch" => "armv7l","libc" => "glibc","march" => "armv7l","libstdcxx_version" => "3.4.24","os" => "linux")
 
     # Parse `"any"` as `AnyPlatform`
     @test tryparse(ExtendedPlatform, "any") == AnyPlatform()
@@ -129,6 +142,41 @@ end
     @test isnothing(tryparse(ExtendedPlatform, "armv7l-linux-musleabihf-this-is+not-valid"))
     # This string doesn't contain valid key-value pairs in the extra part
     @test_throws ArgumentError parse(ExtendedPlatform, "x86_64-linux-gnu-this+is-not-valid")
+
+    @testset "base_platform" begin
+        @test base_platform(Linux(:armv7l)) == Linux(:armv7l)
+        @test base_platform(ExtendedPlatform(FreeBSD(:x86_64); march="avx")) == FreeBSD(:x86_64)
+    end
+
+    @testset "march" begin
+        @test isnothing(march(Linux(:x86_64)))
+        @test isnothing(march(AnyPlatform()))
+        @test isnothing(march(ExtendedPlatform(Windows(:x86_64); cuda="9.2")))
+        @test march(ExtendedPlatform(FreeBSD(:x86_64); march="avx512")) == "avx512"
+    end
+
+    @testset "Sys utilities" begin
+        p = ExtendedPlatform(Linux(:x86_64); cuda="9.2")
+        @test Sys.islinux(p)
+        @test !Sys.isapple(p)
+        @test !Sys.isbsd(p)
+        @test !Sys.iswindows(p)
+        p = ExtendedPlatform(FreeBSD(:x86_64); cuda="9.2")
+        @test !Sys.islinux(p)
+        @test !Sys.isapple(p)
+        @test Sys.isbsd(p)
+        @test !Sys.iswindows(p)
+        p = ExtendedPlatform(MacOS(:x86_64); march="avx512")
+        @test !Sys.islinux(p)
+        @test Sys.isapple(p)
+        @test Sys.isbsd(p)
+        @test !Sys.iswindows(p)
+        p = ExtendedPlatform(Windows(:x86_64); foo="bar")
+        @test !Sys.islinux(p)
+        @test !Sys.isapple(p)
+        @test !Sys.isbsd(p)
+        @test Sys.iswindows(p)
+    end
 
     @testset "Platform matching" begin
         # Extending same platform
@@ -193,4 +241,9 @@ end
     end
     @test BinaryBuilderBase.exeext(Windows(:x86_64)) == ".exe"
     @test BinaryBuilderBase.exeext(Windows(:i686)) == ".exe"
+
+    @test BinaryPlatforms.platform_dlext(ExtendedPlatform(Linux(:aarch64); march="thunderx2")) == "so"
+    @test BinaryPlatforms.platform_dlext(ExtendedPlatform(FreeBSD(:x86_64); march="x86_64")) == "so"
+    @test BinaryPlatforms.platform_dlext(ExtendedPlatform(MacOS(:x86_64); march="avx512")) == "dylib"
+    @test BinaryPlatforms.platform_dlext(ExtendedPlatform(Windows(:i686); cuda="10.1")) == "dll"
 end

--- a/test/platforms.jl
+++ b/test/platforms.jl
@@ -48,61 +48,61 @@ end
     @test parse(ExtendedPlatform, triplet(p)) == p
     meta = Dict{String,String}()
     Artifacts.pack_platform!(meta, p)
-    @test meta == Dict("arch" => "x86_64","libc" => "musl","march" => "avx","os" => "linux")
+    @test meta == Dict("arch" => "x86_64","libc" => "musl","march" => "avx","os" => "linux", "cuda" => "9.2")
 
-    p = ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx03)); microarchitecture="skylake_avx512", cuda="10.1", cuda_capability="52")
-    @test p.p == Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx03))
-    @test p.ext == Dict("microarchitecture" => "skylake_avx512","cuda_capability" => "52","cuda" => "10.1")
+    p = ExtendedPlatform(Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx03)); march="carmel", cuda="10.1", cuda_capability="52")
+    @test p.p == Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx03))
+    @test p.ext == Dict("march" => "carmel","cuda_capability" => "52","cuda" => "10.1")
     @test BinaryPlatforms.platform_name(p) == "ExtendedPlatform"
-    @test BinaryPlatforms.arch(p) == :powerpc64le
+    @test BinaryPlatforms.arch(p) == :aarch64
     @test BinaryPlatforms.libc(p) == :glibc
     @test BinaryPlatforms.call_abi(p) == nothing
     @test BinaryPlatforms.compiler_abi(p) == CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx03)
-    @test BinaryPlatforms.triplet(p) == "powerpc64le-linux-gnu-libgfortran5-cxx03-cuda+10.1-cuda_capability+52-microarchitecture+skylake_avx512"
-    @test replace_cxxstring_abi(p, :cxx11) == ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx11)); microarchitecture="skylake_avx512", cuda="10.1", cuda_capability="52")
-    @test replace_libgfortran_version(p, v"3") == ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3", cxxstring_abi=:cxx03)); microarchitecture="skylake_avx512", cuda="10.1", cuda_capability="52")
-    @test abi_agnostic(p) == Linux(:powerpc64le, libc=:glibc)
-    @test aatriplet(p) == "powerpc64le-linux-gnu"
-    @test get_concrete_platform(p; compilers = [:c, :go], preferred_gcc_version = v"8", preferred_llvm_version = v"6") == ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx03)); microarchitecture="skylake_avx512", cuda_capability="52", cuda="10.1")
-    @test ExtendedPlatform(p; cuda="10.1", foo="bar") == ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0", cxxstring_abi=:cxx03)); microarchitecture="skylake_avx512", cuda_capability="52", cuda="10.1", foo="bar")
-    @test ExtendedPlatform(p; foo="bar") == ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0", cxxstring_abi=:cxx03)); microarchitecture="skylake_avx512", cuda_capability="52", cuda="10.1", foo="bar")
+    @test BinaryPlatforms.triplet(p) == "aarch64-linux-gnu-libgfortran5-cxx03-cuda+10.1-cuda_capability+52-march+carmel"
+    @test replace_cxxstring_abi(p, :cxx11) == ExtendedPlatform(Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx11)); march="carmel", cuda="10.1", cuda_capability="52")
+    @test replace_libgfortran_version(p, v"3") == ExtendedPlatform(Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3", cxxstring_abi=:cxx03)); march="carmel", cuda="10.1", cuda_capability="52")
+    @test abi_agnostic(p) == Linux(:aarch64, libc=:glibc)
+    @test aatriplet(p) == "aarch64-linux-gnu"
+    @test get_concrete_platform(p; compilers = [:c, :go], preferred_gcc_version = v"8", preferred_llvm_version = v"6") == ExtendedPlatform(Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx03)); march="carmel", cuda_capability="52", cuda="10.1")
+    @test ExtendedPlatform(p; cuda="10.1", foo="bar") == ExtendedPlatform(Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0", cxxstring_abi=:cxx03)); march="carmel", cuda_capability="52", cuda="10.1", foo="bar")
+    @test ExtendedPlatform(p; foo="bar") == ExtendedPlatform(Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0", cxxstring_abi=:cxx03)); march="carmel", cuda_capability="52", cuda="10.1", foo="bar")
     @test_throws ErrorException ExtendedPlatform(p; cuda="10.1", cuda_capability="80")
-    @test startswith(repr(p), "ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v\"5.0.0\", cxxstring_abi=:cxx03)); ")
-    @test occursin("microarchitecture=\"skylake_avx512\"", repr(p))
+    @test startswith(repr(p), "ExtendedPlatform(Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v\"5.0.0\", cxxstring_abi=:cxx03)); ")
+    @test occursin("march=\"carmel\"", repr(p))
     @test occursin("cuda=\"10.1\"", repr(p))
     @test occursin("cuda_capability=\"52\"", repr(p))
     @test endswith(repr(p), ")")
     @test parse(ExtendedPlatform, triplet(p)) == p
     meta = Dict{String,String}()
     Artifacts.pack_platform!(meta, p)
-    @test meta == Dict("libgfortran_version" => "5.0.0","arch" => "powerpc64le","libc" => "glibc","os" => "linux","cxxstring_abi" => "cxx03")
+    @test meta == Dict("libgfortran_version" => "5.0.0","arch" => "aarch64","libc" => "glibc","os" => "linux","cxxstring_abi" => "cxx03", "march" => "carmel", "cuda" => "10.1", "cuda_capability" => "52")
 
-    p = ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx11)); microarchitecture="skylake_avx512", cuda="10.1", cuda_capability="52")
-    @test p.p == Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx11))
-    @test p.ext == Dict("microarchitecture" => "skylake_avx512","cuda_capability" => "52","cuda" => "10.1")
+    p = ExtendedPlatform(Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx11)); march="carmel", cuda="10.1", cuda_capability="52")
+    @test p.p == Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx11))
+    @test p.ext == Dict("march" => "carmel","cuda_capability" => "52","cuda" => "10.1")
     @test BinaryPlatforms.platform_name(p) == "ExtendedPlatform"
-    @test BinaryPlatforms.arch(p) == :powerpc64le
+    @test BinaryPlatforms.arch(p) == :aarch64
     @test BinaryPlatforms.libc(p) == :glibc
     @test BinaryPlatforms.call_abi(p) == nothing
     @test BinaryPlatforms.compiler_abi(p) == CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx11)
-    @test BinaryPlatforms.triplet(p) == "powerpc64le-linux-gnu-libgfortran5-cxx11-cuda+10.1-cuda_capability+52-microarchitecture+skylake_avx512"
-    @test abi_agnostic(p) == Linux(:powerpc64le, libc=:glibc)
-    @test aatriplet(p) == "powerpc64le-linux-gnu"
+    @test BinaryPlatforms.triplet(p) == "aarch64-linux-gnu-libgfortran5-cxx11-cuda+10.1-cuda_capability+52-march+carmel"
+    @test abi_agnostic(p) == Linux(:aarch64, libc=:glibc)
+    @test aatriplet(p) == "aarch64-linux-gnu"
     @test replace_cxxstring_abi(p, :cxx11) == p
     @test replace_libgfortran_version(p, v"5") == p
-    @test get_concrete_platform(p; compilers = [:c], preferred_gcc_version = v"5", preferred_llvm_version = v"9") == ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx11)); microarchitecture="skylake_avx512", cuda_capability="52", cuda="10.1")
-    @test ExtendedPlatform(p; cuda="10.1", foo="bar") == ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0", cxxstring_abi=:cxx11)); microarchitecture="skylake_avx512", cuda_capability="52", cuda="10.1", foo="bar")
-    @test ExtendedPlatform(p; foo="bar") == ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0", cxxstring_abi=:cxx11)); microarchitecture="skylake_avx512", cuda_capability="52", cuda="10.1", foo="bar")
+    @test get_concrete_platform(p; compilers = [:c], preferred_gcc_version = v"5", preferred_llvm_version = v"9") == ExtendedPlatform(Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5", cxxstring_abi=:cxx11)); march="carmel", cuda_capability="52", cuda="10.1")
+    @test ExtendedPlatform(p; cuda="10.1", foo="bar") == ExtendedPlatform(Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0", cxxstring_abi=:cxx11)); march="carmel", cuda_capability="52", cuda="10.1", foo="bar")
+    @test ExtendedPlatform(p; foo="bar") == ExtendedPlatform(Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0", cxxstring_abi=:cxx11)); march="carmel", cuda_capability="52", cuda="10.1", foo="bar")
     @test_throws ErrorException ExtendedPlatform(p; cuda="10.1", cuda_capability="80")
-    @test startswith(repr(p), "ExtendedPlatform(Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v\"5.0.0\", cxxstring_abi=:cxx11)); ")
-    @test occursin("microarchitecture=\"skylake_avx512\"", repr(p))
+    @test startswith(repr(p), "ExtendedPlatform(Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v\"5.0.0\", cxxstring_abi=:cxx11)); ")
+    @test occursin("march=\"carmel\"", repr(p))
     @test occursin("cuda=\"10.1\"", repr(p))
     @test occursin("cuda_capability=\"52\"", repr(p))
     @test endswith(repr(p), ")")
     @test parse(ExtendedPlatform, triplet(p)) == p
     meta = Dict{String,String}()
     Artifacts.pack_platform!(meta, p)
-    @test meta == Dict("libgfortran_version" => "5.0.0","arch" => "powerpc64le","libc" => "glibc","os" => "linux","cxxstring_abi" => "cxx11")
+    @test meta == Dict("libgfortran_version" => "5.0.0","arch" => "aarch64","libc" => "glibc","os" => "linux","cxxstring_abi" => "cxx11", "march" => "carmel", "cuda" => "10.1", "cuda_capability" => "52")
 
     p = ExtendedPlatform(Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(; libstdcxx_version=v"3.4.24")); march="armv7l", cuda="11.1")
     @test p.p == Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(; libstdcxx_version=v"3.4.24"))
@@ -128,10 +128,17 @@ end
     @test parse(ExtendedPlatform, triplet(p)) == p
     meta = Dict{String,String}()
     Artifacts.pack_platform!(meta, p)
-    @test meta == Dict("arch" => "armv7l","libc" => "glibc","march" => "armv7l","libstdcxx_version" => "3.4.24","os" => "linux")
+    @test meta == Dict("arch" => "armv7l","libc" => "glibc","march" => "armv7l", "libstdcxx_version" => "3.4.24","os" => "linux", "cuda" => "11.1")
 
-    # Extended platform with wrong microarchitecture
+    # Extended platforms with wrong microarchitecture
     @test_throws ArgumentError ExtendedPlatform(Linux(:x86_64); march="carmel")
+    @test_throws ArgumentError ExtendedPlatform(Linux(:i686); march="haswell")
+    # Extended platform with invalid keys
+    @test_throws ArgumentError ExtendedPlatform(Linux(:x86_64); os="windows")
+    @test_throws ArgumentError ExtendedPlatform(Linux(:i686); libc="musl")
+    # Extended platform with "+" sign in them
+    @test_throws ArgumentError ExtendedPlatform(Linux(:x86_64); invalid="plus+sign")
+    @test_throws ArgumentError ExtendedPlatform(Linux(:i686), Dict("this+is" => "invalid"))
 
     # Parse `"any"` as `AnyPlatform`
     @test tryparse(ExtendedPlatform, "any") == AnyPlatform()
@@ -185,12 +192,12 @@ end
         # Extending same platform
         @test !platforms_match(ExtendedPlatform(Linux(:i686; libc=:musl); cuda="9.2"), ExtendedPlatform(Linux(:i686; libc=:glibc); cuda="9.2"))
         @test platforms_match(ExtendedPlatform(Linux(:i686; libc=:musl); cuda="9.2"), ExtendedPlatform(Linux(:i686; libc=:musl); cuda="9.2"))
-        @test platforms_match(ExtendedPlatform(Linux(:i686; libc=:musl); cuda="9.2"), ExtendedPlatform(Linux(:i686; libc=:musl); cuda="9.2", microarchitecture="avx"))
-        @test !platforms_match(ExtendedPlatform(Linux(:i686; libc=:musl); cuda="9.1"), ExtendedPlatform(Linux(:i686; libc=:musl); cuda="9.2", microarchitecture="avx"))
+        @test platforms_match(ExtendedPlatform(Linux(:aarch64; libc=:musl); cuda="9.2"), ExtendedPlatform(Linux(:aarch64; libc=:musl); cuda="9.2", march="thunderx2"))
+        @test !platforms_match(ExtendedPlatform(Linux(:armv7l; libc=:musl); cuda="9.1"), ExtendedPlatform(Linux(:armv7l; libc=:musl); cuda="9.2", march="neon"))
         # Extending the same platform as the other one
-        @test platforms_match(ExtendedPlatform(Linux(:powerpc64le; compiler_abi=CompilerABI(; libgfortran_version=v"5")); microarchitecture="skylake_avx512"), Linux(:powerpc64le))
-        @test !platforms_match(ExtendedPlatform(Windows(:x86_64); microarchitecture="avx"), Windows(:i686))
-        @test platforms_match(MacOS(:x86_64; compiler_abi=CompilerABI(; cxxstring_abi=:cxx11)), ExtendedPlatform(MacOS(:x86_64); microarchitecture="skylake"))
+        @test platforms_match(ExtendedPlatform(Linux(:x86_64; compiler_abi=CompilerABI(; libgfortran_version=v"5")); march="avx512"), Linux(:x86_64))
+        @test !platforms_match(ExtendedPlatform(Windows(:x86_64); march="avx"), Windows(:i686))
+        @test platforms_match(MacOS(:x86_64; compiler_abi=CompilerABI(; cxxstring_abi=:cxx11)), ExtendedPlatform(MacOS(:x86_64); march="avx512"))
         @test !platforms_match(FreeBSD(:x86_64; compiler_abi=CompilerABI(; cxxstring_abi=:cxx03)), ExtendedPlatform(FreeBSD(:x86_64; compiler_abi=CompilerABI(; cxxstring_abi=:cxx11)); cuda="10.1"))
         # Extending a platform different from the other one
         @test !platforms_match(ExtendedPlatform(Linux(:i686); cuda="9.2"), MacOS(:x86_64))

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -1,6 +1,6 @@
 using Test
 using BinaryBuilderBase
-using BinaryBuilderBase: supported_marchs, dlext, exeext
+using BinaryBuilderBase: dlext, exeext
 
 @testset "Wrappers utilities" begin
     @test nbits(Linux(:i686)) == 32
@@ -18,17 +18,6 @@ using BinaryBuilderBase: supported_marchs, dlext, exeext
     @test proc_family(Linux(:powerpc64le)) == :power
     @test proc_family(AnyPlatform()) == :intel
     @test_throws ErrorException proc_family(UnknownPlatform())
-
-    @test supported_marchs(Linux(:i686)) == []
-    @test supported_marchs(Linux(:x86_64)) == ["avx", "avx2", "avx512", "x86_64"]
-    @test supported_marchs(Linux(:armv7l)) == ["armv7l", "neon", "vfp4"]
-    # This extended platform doesn't specify a microarchitecture, so we can support all of them
-    @test supported_marchs(ExtendedPlatform(Linux(:aarch64); cuda="10.1")) == ["armv8", "carmel", "thunderx2"]
-    @test supported_marchs(Linux(:powerpc64le)) == []
-    # This extended platform specifies a valid microarchitecture, so we support only the given architecture
-    @test supported_marchs(ExtendedPlatform(Linux(:x86_64); march="avx")) == ["avx"]
-    @test supported_marchs(AnyPlatform()) == []
-    @test supported_marchs(UnknownPlatform()) == []
 
     @test dlext(Linux(:i686)) == "so"
     @test dlext(FreeBSD(:x86_64)) == "so"

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -1,5 +1,56 @@
 using Test
 using BinaryBuilderBase
+using BinaryBuilderBase: supported_marchs, dlext, exeext
+
+@testset "Wrappers utilities" begin
+    @test nbits(Linux(:i686)) == 32
+    @test nbits(ExtendedPlatform(Linux(:x86_64); march="avx")) == 64
+    @test nbits(Linux(:armv7l)) == 32
+    @test nbits(ExtendedPlatform(Linux(:aarch64); cuda="10.1")) == 64
+    @test nbits(Linux(:powerpc64le)) == 64
+    @test nbits(AnyPlatform()) == 64
+    @test_throws ErrorException nbits(UnknownPlatform())
+
+    @test proc_family(Linux(:i686)) == :intel
+    @test proc_family(ExtendedPlatform(Linux(:x86_64); march="avx")) == :intel
+    @test proc_family(Linux(:armv7l)) == :arm
+    @test proc_family(ExtendedPlatform(Linux(:aarch64); cuda="10.1")) == :arm
+    @test proc_family(Linux(:powerpc64le)) == :power
+    @test proc_family(AnyPlatform()) == :intel
+    @test_throws ErrorException proc_family(UnknownPlatform())
+
+    @test supported_marchs(Linux(:i686)) == []
+    @test supported_marchs(Linux(:x86_64)) == ["avx", "avx2", "avx512", "x86_64"]
+    @test supported_marchs(Linux(:armv7l)) == ["armv7l", "neon", "vfp4"]
+    # This extended platform doesn't specify a microarchitecture, so we can support all of them
+    @test supported_marchs(ExtendedPlatform(Linux(:aarch64); cuda="10.1")) == ["armv8", "carmel", "thunderx2"]
+    @test supported_marchs(Linux(:powerpc64le)) == []
+    # This extended platform specifies a valid microarchitecture, so we support only the given architecture
+    @test supported_marchs(ExtendedPlatform(Linux(:x86_64); march="avx")) == ["avx"]
+    # This extended platform specifies an invalid microarchitecture (it is valid
+    # for a different platform), so we don't support it
+    @test supported_marchs(ExtendedPlatform(Linux(:x86_64); march="carmel")) == []
+    @test supported_marchs(AnyPlatform()) == []
+    @test supported_marchs(UnknownPlatform()) == []
+
+    @test dlext(Linux(:i686)) == "so"
+    @test dlext(FreeBSD(:x86_64)) == "so"
+    @test dlext(MacOS(:x86_64)) == "dylib"
+    @test dlext(Windows(:i686)) == "dll"
+    @test dlext(ExtendedPlatform(Linux(:x86_64); march="avx512")) == "so"
+    @test_throws ErrorException dlext(AnyPlatform())
+    @test_throws ErrorException dlext(UnknownPlatform())
+
+    @test exeext(Linux(:i686)) == ""
+    @test exeext(FreeBSD(:x86_64)) == ""
+    @test exeext(MacOS(:x86_64)) == ""
+    @test exeext(Windows(:i686)) == ".exe"
+    @test exeext(ExtendedPlatform(Linux(:x86_64); march="avx512")) == ""
+    @test_throws ErrorException exeext(AnyPlatform())
+    @test_throws ErrorException exeext(UnknownPlatform())
+
+    @test aatriplet(ExtendedPlatform(Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0")); march="avx", cuda="9.2")) == "x86_64-linux-gnu"
+end
 
 # Are we using docker? If so, test that the docker runner works...
 @testset "Runner utilities" begin

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -27,9 +27,6 @@ using BinaryBuilderBase: supported_marchs, dlext, exeext
     @test supported_marchs(Linux(:powerpc64le)) == []
     # This extended platform specifies a valid microarchitecture, so we support only the given architecture
     @test supported_marchs(ExtendedPlatform(Linux(:x86_64); march="avx")) == ["avx"]
-    # This extended platform specifies an invalid microarchitecture (it is valid
-    # for a different platform), so we don't support it
-    @test supported_marchs(ExtendedPlatform(Linux(:x86_64); march="carmel")) == []
     @test supported_marchs(AnyPlatform()) == []
     @test supported_marchs(UnknownPlatform()) == []
 


### PR DESCRIPTION
This is still very much work in progress

Still to do:
* [ ] Need to define an `extended_platform_key_abi()`?
* [x] Extend [`gcc_version`](https://github.com/JuliaPackaging/BinaryBuilderBase.jl/blob/d6d3aa9c072f925fbe3cd10d7c0c20db8f1c167e/src/Rootfs.jl#L375-L411) to take march into account?
* [ ] Inform auditor about the march
  * [ ] Fix [`is_for_platform`](https://github.com/JuliaPackaging/BinaryBuilder.jl/blob/b13d66169cf84fc1e1193ebbc0fb16910c9a6f34/src/auditor/dynamic_linkage.jl#L60-L127) to use `base_platform` defined in this PR.  It should use `arch()` function instead of accessing `.arch` field
* [ ] Teach [`minimum_instruction_set`](https://github.com/JuliaPackaging/BinaryBuilder.jl/blob/b13d66169cf84fc1e1193ebbc0fb16910c9a6f34/src/auditor/instruction_set.jl#L1163-L1188) more instruction sets
  * It would be great to issue a warning if we're building for an higher instruction sets, but none (or very few?) of those instructions are used, so to avoid building useless stuff