### PR TITLE
mkdir target directory when copying for DirectorySource

### DIFF
--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -296,13 +296,12 @@ function setup(source::SetupSource{FileSource}, target, verbose)
 end
 
 function setup(source::SetupSource{DirectorySource}, targetdir, verbose)
+    mkpath(targetdir)
     # Need to strip the trailing separator also here
     srcpath = strip_backslash(source.path)
     if verbose
         @info "Copying content of $(basename(srcpath)) in $(basename(targetdir))..."
     end
-    # Create if missing. Will throw an IOError if targetdir is there, but not a directory.
-    mkpath(targetdir)
     for file_dir in readdir(srcpath)
         # Copy the content of the source directory to the destination
         cp(joinpath(srcpath, file_dir), joinpath(targetdir, basename(file_dir));

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -302,7 +302,7 @@ function setup(source::SetupSource{DirectorySource}, targetdir, verbose)
         @info "Copying content of $(basename(srcpath)) in $(basename(targetdir))..."
     end
     # Create if missing. Will throw an IOError if targetdir is there, but not a directory.
-    isdir(targetdir) || mkdir(targetdir)
+    mkpath(targetdir)
     for file_dir in readdir(srcpath)
         # Copy the content of the source directory to the destination
         cp(joinpath(srcpath, file_dir), joinpath(targetdir, basename(file_dir));

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -301,6 +301,8 @@ function setup(source::SetupSource{DirectorySource}, targetdir, verbose)
     if verbose
         @info "Copying content of $(basename(srcpath)) in $(basename(targetdir))..."
     end
+    # Create if missing. Will throw an IOError if targetdir is there, but not a directory.
+    isdir(targetdir) || mkdir(targetdir)
     for file_dir in readdir(srcpath)
         # Copy the content of the source directory to the destination
         cp(joinpath(srcpath, file_dir), joinpath(targetdir, basename(file_dir));


### PR DESCRIPTION
I was running into an issue when my sources were just two `DirectorySources`, something like this:

```julia
sources = [
    DirectorySource("./src"), # should become ${WORKSPACE}/srcdir
    DirectorySource("./mysubdir", target="mysubdir"), # should become ${WORKSPACE}/srcdir/mysubdir
]
```

`build_tarballs` would then fail when it's copying over the second one with an exception on line 308, because it tries to copy into a non-existing directory.

Don't really know if this is the correct solution, or maybe my `sources` setup is just wrong, but it seems to work for me (TM).