### PR TITLE
Remove at-ref to BinaryBuilder.build_tarballs

### DIFF
--- a/src/Products.jl
+++ b/src/Products.jl
@@ -230,7 +230,7 @@ end
 A `FrameworkProduct` is a  [`Product`](@ref) that encapsulates a macOS Framework.
 It behaves mostly as a [`LibraryProduct`](@ref) for now, but is a distinct type.
 This implies that for cross-platform builds where a library is provided as a Framework
-on macOS and as a normal library on other platforms, two calls to [`build_tarballs`](@ref)
+on macOS and as a normal library on other platforms, two calls to BinaryBuilder's `build_tarballs`
 are needed: one with the `LibraryProduct` and all non-macOS platforms, and one with the `FrameworkProduct`
 and the `MacOS` platforms.
 """


### PR DESCRIPTION
The at-ref currently causes a documentation build warning because Documenter can't resolve it. This is true both in the BinaryBuilderBase docs (doesn't know anything about `build_tarballs`), but also in BinaryBuilder docs (which includes BinaryBuilderBase docstrings too; `build_tarballs` of course exists, but Documenter still can't resolve it because it's in a different package).

