### PR TITLE
Add `GNU_LIBC_VERSION` to the mappings of the build environment

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -726,6 +726,22 @@ function platform_envs(platform::Platform, src_name::AbstractString; host_platfo
         end
     end
 
+    # There is no easy way to automatically determine the version of glibc for
+    # all platforms, but some build systems want to know it.  Let's emulate with
+    # the `GNU_LIBC_VERSION` environment variable what `getconf
+    # GNU_LIBC_VERSION` would return, if it worked.
+    if libc(platform) === :glibc
+        # This should be kept in sync with the version of glibc used in
+        # https://github.com/JuliaPackaging/Yggdrasil/blob/master/0_RootFS/gcc_common.jl
+        if arch(platform) in (:x86_64, :i686)
+            mapping["GNU_LIBC_VERSION"] = "glibc 2.12.2"
+        elseif arch(platform) in (:armv7l, :aarch64)
+            mapping["GNU_LIBC_VERSION"] = "glibc 2.19"
+        elseif arch(platform) === :powerpc64le
+            mapping["GNU_LIBC_VERSION"] = "glibc 2.17"
+        end
+    end
+
     return mapping
 end
 


### PR DESCRIPTION
I've looked into automatically determining the version of glibc a few times, but never found a general solution (only something that would work for `x86_64-linux-gnu`).  However some build systems insist on getting the version of glibc with `getconf GNU_LIBC_VERSION`, which however doesn't work, see for example https://github.com/SCIP-Interfaces/SCIP.jl/issues/165.  My proposal is to have an environment variable that at least gives the same result.  I guess someone might suggest to have a `getconf` script in the rootfs which simply does `echo ${@}`