### PR TITLE
Default to more explicit `dlopen_flags_str()`.

### DIFF
--- a/src/Products.jl
+++ b/src/Products.jl
@@ -126,9 +126,10 @@ end
 
 function dlopen_flags_str(p::LibraryProduct)
     if length(p.dlopen_flags) > 0
-        return ", $(join(p.dlopen_flags, " | "))"
+        return join(p.dlopen_flags, " | ")
     else
-        return ""
+        # This is the default if no flags are specified
+        return "RTLD_LAZY | RTLD_DEEPBIND"
     end
 end
 

--- a/test/products.jl
+++ b/test/products.jl
@@ -183,7 +183,7 @@ end
     @test fp.libraryproduct.dlopen_flags == [:RTLD_GLOBAL, :RTLD_NOLOAD]
     for p in (lp, fp)
         flag_str = BinaryBuilderBase.dlopen_flags_str(p)
-        @test flag_str == ", RTLD_GLOBAL | RTLD_NOLOAD"
-        @test Libdl.eval(Meta.parse(flag_str[3:end])) == (Libdl.RTLD_NOLOAD | Libdl.RTLD_GLOBAL)
+        @test flag_str == "RTLD_GLOBAL | RTLD_NOLOAD"
+        @test Libdl.eval(Meta.parse(flag_str)) == (Libdl.RTLD_NOLOAD | Libdl.RTLD_GLOBAL)
     end
 end


### PR DESCRIPTION
This will be more extensible in the future; it always makes me a little uncomfortable to have things like `func(arg1, arg2$(maybe_arg3)` where `maybe_arg3` has the comma embedded within it.