### PR TITLE
Switch `Base.have_color` to `get(stdout, :color, false)`

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -607,7 +607,7 @@ function platform_envs(platform::Platform, src_name::AbstractString; host_platfo
         libdir = "$(prefix)/lib"
     end
 
-    if Base.have_color
+    if get(stdout, :color, false)
         PS1 = string(
             raw"\[",
             Base.text_colors[:light_blue],


### PR DESCRIPTION
This avoids the issue of `Base.have_color` now being able to be
`nothing` in Julia `v1.5`.