### PR TITLE
Bump x86_64-linux-gnu, x86_64-linux-musl and x86_64-unknown-freebsd11.1 shards

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1210,377 +1210,377 @@ os = "linux"
 
 [["GCCBootstrap-x86_64-linux-gnu.v5.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "59f34d3674ad1e117a5112cd51f4babb258917ec"
+git-tree-sha1 = "85a973f349179b6264b90f07ac7e94220ca20003"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-gnu.v5.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "f3f5fff456f9a5f3176aba4066566201bb09acea543c207b1be6b59b38934561"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+1/GCCBootstrap-x86_64-linux-gnu.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "a7b2302d47e6be17d611c00d65a0d6a2546b75445cacf59bfc7080d19952f985"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+2/GCCBootstrap-x86_64-linux-gnu.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-gnu.v5.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "d833c5a147987220348af404ba1afc54af455d16"
+git-tree-sha1 = "f9e4eeaa496895642c65378ba90bdac48287b2c4"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-gnu.v5.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "e29eb1e5df7093a7b6ec7b6d2502fb0c1d9534206d3854aee7b55feb8763b41a"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+1/GCCBootstrap-x86_64-linux-gnu.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "2b2c3a875508e8070faa7eca711b03df8961db4be8fc4cc36f37d0960de507a9"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+2/GCCBootstrap-x86_64-linux-gnu.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-gnu.v6.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "667c07086eb04bab8dab10653a4c35e79b30be02"
+git-tree-sha1 = "b9e06bc8f9d64045bee8392608a6c7cf164f02bf"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-gnu.v6.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "a0f4371aaa70bd1e88c98360a7016c52ed97e305bbb97603cd1c32797e8d72cb"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+1/GCCBootstrap-x86_64-linux-gnu.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "f46937104396e917a970c9a4e42540162f746d86e70299cdba5c3cf5866864f6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+2/GCCBootstrap-x86_64-linux-gnu.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-gnu.v6.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "217178e7c72dc20e353c6fd823a91e9d96c84e54"
+git-tree-sha1 = "6715fd275fa734351d18e796bf148cbb7b2eb6da"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-gnu.v6.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "0c7e4e0325413072df0f1fe0f3fa5245eb916bb7a1c2b84a9e05169423e53e5a"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+1/GCCBootstrap-x86_64-linux-gnu.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "10f06b53586462fad9932ae631efaf88db3b4051fd756c7379978c38e73df773"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+2/GCCBootstrap-x86_64-linux-gnu.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-gnu.v7.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "8dfbdc1e6afa9ac083beec01ea119b532c0a16f9"
+git-tree-sha1 = "f4531a4911e9761dc058184b6f23be44848a286a"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-gnu.v7.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "e1b45d8a773d06da79c3cc6faea4846877ff96f7dda80a15658c0df294921a61"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+1/GCCBootstrap-x86_64-linux-gnu.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "bd8f83c77932f2e095e7f900a9705cffa1f9b1808d05934fd52c81ebbd8eff11"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+2/GCCBootstrap-x86_64-linux-gnu.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-gnu.v7.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "ba7056d76ddde80b1090212eb6014a86bfe0a3ec"
+git-tree-sha1 = "1de9e1df266a1386e30cff2f08023dc0f3c36375"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-gnu.v7.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "fbff54d12c24a6f666c499e2ef72f3383127a37586c254637a54288b03bb351e"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+1/GCCBootstrap-x86_64-linux-gnu.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "977bf5295fa47d8c4d0b10467a6a8b5db95c4b2fb7bc1706df648e75d4318171"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+2/GCCBootstrap-x86_64-linux-gnu.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-gnu.v8.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "1f2f4bbcff6314144fcd09d48c63d365dda9e8a5"
+git-tree-sha1 = "d8fb1cb219e642adf6384f357acd347ed7e73f47"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-gnu.v8.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "b82ca0797b1231a8ca361d1973874c17b724595540d1c31b8067f3f463f351d5"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+1/GCCBootstrap-x86_64-linux-gnu.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "f8ad67c7e6effceaf1c5fb5f167d0cf571b89ff211d61d045e077e35debe7839"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+2/GCCBootstrap-x86_64-linux-gnu.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-gnu.v8.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "04dfabf9670c1e9c8abcd2a28efc957475551c69"
+git-tree-sha1 = "f50c3ba869c2ea0ef31a34c9e6523076985b5c9e"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-gnu.v8.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "98c5eaa15e2efd8868dc291f076cea8bb422a01a2aa81313261e6212e8ae6308"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+1/GCCBootstrap-x86_64-linux-gnu.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "8f64ff582b19c8741b7afc4a042be0e34c3bce07d3a71151d95eef05eb32453b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+2/GCCBootstrap-x86_64-linux-gnu.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-gnu.v9.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "26b7a5bb23c599cd434721fb1b441048875a781f"
+git-tree-sha1 = "c90af6b5c9148fbe096acf2741ce6aa52bf03cd5"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-gnu.v9.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "b4aedebdfb3aa6fed3f601a456e0a4fa3c124c5151fa87d692a2e79083a13ea5"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+1/GCCBootstrap-x86_64-linux-gnu.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "77e759a0c67d53651c1ee42d9e17ff8263128b5a346036a8edcee8f7a62826d5"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+2/GCCBootstrap-x86_64-linux-gnu.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-gnu.v9.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "0328be9cdf34fb6d3f463f8fdd8d3e3645a2e92d"
+git-tree-sha1 = "db6b14fdcb8fb209ea6039d8ad83faf5da68b0bc"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-gnu.v9.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "104145db45b070959ad2ef7f595a4a09198d8c637daa785de8ef45c6864f9943"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+1/GCCBootstrap-x86_64-linux-gnu.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "f4550645592653d21ffcaf1fc67bba734105aaa541fc0468193e358ec303ae2e"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+2/GCCBootstrap-x86_64-linux-gnu.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-musl.v4.8.5.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "2a48662278117860322899d2f8e596274adfa35c"
+git-tree-sha1 = "46836728a90139d3969322fc5c62e627b91ffa70"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-musl.v4.8.5.x86_64-linux-musl.squashfs".download]]
-    sha256 = "a770c58d95111f9ee103ba5d82d9f396ea65313141a77dfb7021c088f617fe93"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+1/GCCBootstrap-x86_64-linux-musl.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "379f71de86ad743176a8062f26efb4e89f04b92abdb4736ec41f66dd87b9f871"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+2/GCCBootstrap-x86_64-linux-musl.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-musl.v4.8.5.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "2c3fbf82bdc3fa7f35a7a80b167b391e91c0b7fe"
+git-tree-sha1 = "9cc58bc11f87ea70486abef944f3691370207b1b"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-musl.v4.8.5.x86_64-linux-musl.unpacked".download]]
-    sha256 = "36f35d60fc913a7977f347e616e1117354d26670ad2830ba4dfc35d5286a499d"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+1/GCCBootstrap-x86_64-linux-musl.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "7b40ec8423204e769a161f96c69786c1425808b859e4677528591d87f348b9b1"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+2/GCCBootstrap-x86_64-linux-musl.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-musl.v5.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "7e8b62b1c20d8c4798ec1ff69681d71e9fbb230a"
+git-tree-sha1 = "0aeef12a9b622a52df45d8638a2907fc8da114fc"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-musl.v5.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "7a38d03b4f701e09aaaf2c03996c8b99fa45d6e456f300c0c80370678a15ff63"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+1/GCCBootstrap-x86_64-linux-musl.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "c276a409b6c4aa572e69a59895d3b3aa95fbb354e96461c56e726bbe920a5cab"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+2/GCCBootstrap-x86_64-linux-musl.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-musl.v5.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "59a574ef9854e237ae64983e78f957695ab71fe5"
+git-tree-sha1 = "24ea9639de6f86765b1feb712e4dfa1b70a9eebc"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-musl.v5.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "a56838b74cc9e9a5cc9eecc8ad4bc3dc5a47ccee7984dad433057f161df98ae1"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+1/GCCBootstrap-x86_64-linux-musl.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "c7074b6d5ff633a732668854179bac2fd9dc95555029f076b753ee2edd484a86"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+2/GCCBootstrap-x86_64-linux-musl.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-musl.v6.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "6279289d40ce5557c2d2dd08579cbea49f212988"
+git-tree-sha1 = "39ca9f6b5c42910be827addc77cfa2f6ebb3d690"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-musl.v6.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "a4fb743c451a1d2ab7072f7016c70e33cccdac23413d36b48a7de910b4dd2adc"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+1/GCCBootstrap-x86_64-linux-musl.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "c90c245911c7f84dbe09f2479deda57ebee3eff17f1065779c9c30b876a96f8a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+2/GCCBootstrap-x86_64-linux-musl.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-musl.v6.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "10426070adc07a5f257732acaccc3c616655c2ed"
+git-tree-sha1 = "275ab2c29f7ff6871853b70804ff7cfcc2b10ec4"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-musl.v6.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "f02c939e9cb31c5fb5a8f2c3e64f74db2988fb9c0bba2c1c5448eedc488e7cd5"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+1/GCCBootstrap-x86_64-linux-musl.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "f40c081328e088b0f42a1eba7bd67d42f17e727955fac0b664977abc51665742"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+2/GCCBootstrap-x86_64-linux-musl.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-musl.v7.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "539f9cb29cdbf899801be0005dfb5d10437e9bf0"
+git-tree-sha1 = "1db1540f04c3eddc0497ac26bbc3eb85b04f22c7"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-musl.v7.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "b085e4b3d0195c98cad896554b987857d2e7217a569c04e7c70dd56187e958d4"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+1/GCCBootstrap-x86_64-linux-musl.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "229ad131e0c50c615a66a4054e89986c6c90a9b523fdcf106c2d109989847936"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+2/GCCBootstrap-x86_64-linux-musl.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-musl.v7.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "71c4fd66a3efb66f526ea62db2f8814ad4d42911"
+git-tree-sha1 = "68e086e4634f739db495f235dbec984c88bf7f74"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-musl.v7.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "7a67dbca2d21def5085ca347a062255c3c41767b29ce38c173d38a4bc7639773"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+1/GCCBootstrap-x86_64-linux-musl.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "847bb81f07b43a4d29c0fddc769e94abdee04dabe7071bc8573cab3aadb12de3"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+2/GCCBootstrap-x86_64-linux-musl.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-musl.v8.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "cdedf337b2efc143f4005fde7232474064662705"
+git-tree-sha1 = "19e67f6fb166b8b4b55f72fee248d2c0edd84f81"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-musl.v8.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "57dff0dd9b546db037abeed99e4a369d62a6ad24c0a7a0ddc9252427674829d1"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+1/GCCBootstrap-x86_64-linux-musl.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "159b6af42691643aee31a53542ec77cab4539c640e30badc5b3028565b9c61ca"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+2/GCCBootstrap-x86_64-linux-musl.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-musl.v8.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "22ce4010ff5b3a7f2d30c53507f6a068f48fdf6e"
+git-tree-sha1 = "10570b273a50d2f8dff42c3ee27ea82f74f4b3eb"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-musl.v8.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "8d901cc47a82c3fbcc0d21dcbc46cb47afae66914405ac5fbd9c3aae94083fb7"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+1/GCCBootstrap-x86_64-linux-musl.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "a86e55a55b8301eec92d0db07de515158c1d2cf69b4b690367582d245c9570e9"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+2/GCCBootstrap-x86_64-linux-musl.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-musl.v9.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "386ebee9f88e1c5f07c45e4ee163bb93f10e2cf8"
+git-tree-sha1 = "0e669f59bf60c1653d71b0e9b53659e6ef47aca5"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-musl.v9.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "0a053e90b99f3b79c7db894a27296c16f39ea3d3b78cca74ef3704b2904c0546"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+1/GCCBootstrap-x86_64-linux-musl.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "6e07b6c35d7999519494ae543db54bcf8d0f762d0404a6aca01f84933c420ca1"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+2/GCCBootstrap-x86_64-linux-musl.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-musl.v9.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "985580bf8d0d8e194278607deefbce1a9817555e"
+git-tree-sha1 = "1a53e5644a247849ce2733f537ecf0ee35a868f9"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-linux-musl.v9.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "6fdeafaee3c39abec5e075b3e097153ab8b32b2b864a6968b41b71de76fcb993"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+1/GCCBootstrap-x86_64-linux-musl.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "04dd7bd3a1d1b04341598675fc29e501d98db40add7683a108240a9f21c99ffa"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+2/GCCBootstrap-x86_64-linux-musl.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-unknown-freebsd11.1.v4.8.5.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "01b3816a1b55579a744aa3626f58cba14101d6e5"
+git-tree-sha1 = "1f219fc3959e2611a91c997b76f9a585df12fbce"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-unknown-freebsd11.1.v4.8.5.x86_64-linux-musl.squashfs".download]]
-    sha256 = "d992cb8c6daca247252ae99792e496afc24b7b4e6be3a6b459366d13efe2f0ba"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+1/GCCBootstrap-x86_64-unknown-freebsd11.1.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "2a860b99caf3bc4f59f37f2ceeb99c2fec252c4eb03761cd9fa073d288beb9d8"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+2/GCCBootstrap-x86_64-unknown-freebsd11.1.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-unknown-freebsd11.1.v4.8.5.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "3ff897474e00368b61e005a4a0c6f531887bd31e"
+git-tree-sha1 = "be439b7fdd952e935e0fe8502f3c6a3923521c5e"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-unknown-freebsd11.1.v4.8.5.x86_64-linux-musl.unpacked".download]]
-    sha256 = "3c66d2d96942e7b8c863d3edb0e988efa3eaf84eac95a61ac7e05379fe5bbdf1"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+1/GCCBootstrap-x86_64-unknown-freebsd11.1.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "b5a20daf7a9d7666b14898ab90a8e67483598ca5a4c94c0d58ad72d66f58b6da"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+2/GCCBootstrap-x86_64-unknown-freebsd11.1.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-unknown-freebsd11.1.v5.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "afc299b57a35912978fa301ab6e9f0011e0c9533"
+git-tree-sha1 = "8c13ac1c8d4dbf102829de6b3ceda2ece0c5956b"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-unknown-freebsd11.1.v5.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "4ec12a64e2f0f10972a894ebcb55ebc78110f25a014121ad1e07e91045f2d8a9"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+1/GCCBootstrap-x86_64-unknown-freebsd11.1.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "ea501ea8a8b24de8a19920d2443ccf8d233075a7efafceab3844147adb736aed"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+2/GCCBootstrap-x86_64-unknown-freebsd11.1.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-unknown-freebsd11.1.v5.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "00a8d91b1d5218cdde80141cc41b233e59158b28"
+git-tree-sha1 = "7ec0eb2cebcb2218eecb9d517be67e51751392f3"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-unknown-freebsd11.1.v5.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "3fd9f3961cb1cd8a5f4c93b998e72a1321940ecac34916939cc2cb746ec7060f"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+1/GCCBootstrap-x86_64-unknown-freebsd11.1.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "6157c7c7392a77128dd3ff50dc70d11bff9d3ed7369a502b05b32e9a73f7f10c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+2/GCCBootstrap-x86_64-unknown-freebsd11.1.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-unknown-freebsd11.1.v6.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "980ac55a8e9057e76be3778d650f2bf0a21df6af"
+git-tree-sha1 = "22824c0df2205a6bca2a4526a8a7078d4fd7e35f"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-unknown-freebsd11.1.v6.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "4e1ed6526d758553ee5b60c9fe6cc9ea241b8d5764ec0ecd6d87c53136599c5d"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+1/GCCBootstrap-x86_64-unknown-freebsd11.1.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "e37d774175600f148010af30e26d4f9803a566e9a6d3365b72b1f86a8a62753d"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+2/GCCBootstrap-x86_64-unknown-freebsd11.1.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-unknown-freebsd11.1.v6.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "b8b240bfe2c812ca68829ad6f18d30d363862e13"
+git-tree-sha1 = "4c2acdb49c0faddf11458b3468e5970ad7194735"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-unknown-freebsd11.1.v6.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "b0b2848359df6fc23b63cf95b567fa0fb700f315375fac574f32650be10f39e2"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+1/GCCBootstrap-x86_64-unknown-freebsd11.1.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "0fd6093bcfe4aa1b54f11eb0b9e6c7a128040c211546d8af25124096ef38af36"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+2/GCCBootstrap-x86_64-unknown-freebsd11.1.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-unknown-freebsd11.1.v7.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "c3ec04388007bb59e03b828d2619a9fccce3a8d9"
+git-tree-sha1 = "cb70f046a096509e63c628e2249ff79494c69269"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-unknown-freebsd11.1.v7.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "c9a145b28d5d6da78f8ba904bec959014d889c8b51c3787d1e73948a05a9801a"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+1/GCCBootstrap-x86_64-unknown-freebsd11.1.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "e44958abdf10d9ae2829b824325dae0f1835b4779f5d63948df70f36693b69ed"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+2/GCCBootstrap-x86_64-unknown-freebsd11.1.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-unknown-freebsd11.1.v7.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "08356e68646d93902057f1ce9ac6d9c4137f535d"
+git-tree-sha1 = "ab4bb00db2c20eaf550b4fd761e131bbda6ed236"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-unknown-freebsd11.1.v7.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "80ee34e3eb3f6e0e677861792e06079cb193d9c01af1a3c416d214f43a860c24"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+1/GCCBootstrap-x86_64-unknown-freebsd11.1.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "5b3629718a95929402747f684c1b75c9512b9a94b0d56a76934ce0dc6db08fb3"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+2/GCCBootstrap-x86_64-unknown-freebsd11.1.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-unknown-freebsd11.1.v8.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "39e1598157252e038869d2f3b15f3555aad5c92c"
+git-tree-sha1 = "5c67b52ebfa9f26ce36a329941addd84e91264e1"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-unknown-freebsd11.1.v8.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "2d0a545c04b216ba9947e9f019f37b899928f27941718b0b8596589b49b291c0"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+1/GCCBootstrap-x86_64-unknown-freebsd11.1.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "f3a7875d8c1aad95bb95be0b7f9f96e6f4c0abfb7ac093c5b46f8355283592aa"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+2/GCCBootstrap-x86_64-unknown-freebsd11.1.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-unknown-freebsd11.1.v8.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "7812995e0c9e017ea6094169014063e0a1954660"
+git-tree-sha1 = "1948a99f3c77e5ed6acb504952cfec24fff76e52"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-unknown-freebsd11.1.v8.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "b87d2f8498719fb375ee2a6ecf76c5cfe9bf2e9a2ec61503bc0878edc105db20"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+1/GCCBootstrap-x86_64-unknown-freebsd11.1.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "69ad17d1f2d11a53657d86916da2083bbef3f4cde6f356be2d7f9e9805549211"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+2/GCCBootstrap-x86_64-unknown-freebsd11.1.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-unknown-freebsd11.1.v9.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "56e74c049c4d885f0452ec5659c4d5af50278461"
+git-tree-sha1 = "b10347e77474e0bbb58416ef984446eea76b4284"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-unknown-freebsd11.1.v9.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "41c137bc7d15b0b2c00b3f3cd1c748a536f71909196d7118819f2554548bc95e"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+1/GCCBootstrap-x86_64-unknown-freebsd11.1.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "687f3c75b1097d804f0fe3e00be97baba895a914e34038e061163a5b6f12bf8b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+2/GCCBootstrap-x86_64-unknown-freebsd11.1.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-unknown-freebsd11.1.v9.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "71622b7be0043a1e52ad7e7e74e23889854a2007"
+git-tree-sha1 = "9d46224f8d459f1a845d23360afddfcd481c8b02"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-unknown-freebsd11.1.v9.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "6d9e1ea3920d6153183302753260d59cb4ca4f3eb06577c58c302fcd01c109e7"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+1/GCCBootstrap-x86_64-unknown-freebsd11.1.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "a0c61e9cc80ce0e36e61826a6b57e1b6168fcaef28861fc71378bd6cde9bc897"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+2/GCCBootstrap-x86_64-unknown-freebsd11.1.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v4.8.5.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"


### PR DESCRIPTION
These rebuilt shards fix the following problems:

* `with-arch` was not actually set, despite claims to the contrary.  Because the only users complaining about these issues are on Linux and FreeBSD, we are only rebuilding these shards right now, pending future issues that will no doubt be coming soon.

* `x86_64-linux-musl` lacked a patch that fixed include paths for C++ code on GCC 6+.