### PR TITLE
Pass `-headerpad_max_install_names` to macOS linker

### DIFF
--- a/src/Platforms.jl
+++ b/src/Platforms.jl
@@ -20,7 +20,7 @@ Base.show(io::IO, ::AnyPlatform) = print(io, "AnyPlatform()")
 ## The extended platforms, to represent platforms beyond the standard ones in
 ## Pkg.BinaryPlatforms.
 
-const ARCHITECTURE_FLAGS = begin
+const ARCHITECTURE_FLAGS = let
     # Better be always explicit about `-march` & `-mtune`:
     # https://lemire.me/blog/2018/07/25/it-is-more-complicated-than-i-thought-mtune-march-in-gcc/
     march_flags(arch) = ["-m$(f)=$(arch)" for f in ("arch", "tune")]


### PR DESCRIPTION
This fixes an issue with `install_name_tool` not being able to fix rpath of some
ICU libraries for macOS, see
https://github.com/JuliaPackaging/Yggdrasil/issues/1668 and
https://github.com/JuliaPackaging/Yggdrasil/issues/1650#issuecomment-691369425
for reference.

I'm not 100% sure whether we should always enable it or an case-by-case basis, like https://github.com/JuliaPackaging/Yggdrasil/pull/1670.  Homebrew used to use this flag as well in an old version: https://github.com/Homebrew/legacy-homebrew/commit/585d7c6e650f18820092f263d0e20cfae730f5c1, but I can't find whether it's currently used by default.