### PR TITLE
Add keyword to `expand_cxxstring_abis` to skip FreeBSD and MacOS

### DIFF
--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -27,6 +27,10 @@ using BinaryBuilderBase: supported_microarchitectures
         Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
     ]
     @test expand_cxxstring_abis([FreeBSD(:x86_64), MacOS(:x86_64)]) == [
+        FreeBSD(:x86_64),
+        MacOS(:x86_64),
+    ]
+    @test expand_cxxstring_abis([FreeBSD(:x86_64), MacOS(:x86_64)]; skip_freebsd_macos=false) == [
         FreeBSD(:x86_64, compiler_abi=CompilerABI(cxxstring_abi=:cxx03)),
         FreeBSD(:x86_64, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
         MacOS(:x86_64, compiler_abi=CompilerABI(cxxstring_abi=:cxx03)),


### PR DESCRIPTION
I'm not entirely sure this is a desirable feature because I think it'd make stuff like [`contrib/refresh_bb_tarballs.sh`](https://github.com/JuliaLang/julia/blob/eeffe578534289e4e99f72db263564173188b052/contrib/refresh_bb_tarballs.sh) more complicated.  However, in principle I believe this is a good thing to do, since when building for FreeBSD and macOS we usually don't link to libstdc++, and auditor would yell at us if there is something wrong.  I'm also happy to default `skip_freebsd_macos` to `false`