### PR TITLE
Add HostBuildDependency

### DIFF
--- a/src/Dependencies.jl
+++ b/src/Dependencies.jl
@@ -87,7 +87,7 @@ is_runtime_dependency(::BuildDependency) = false
     HostBuildDependency(dep::Union{PackageSpec,String})
 
 Define a binary dependency that is necessary only to build the package.
-Differently from the [`BuildDependency`](@ref), the artifact for the host
+Different from the [`BuildDependency`](@ref), the artifact for the host
 platform will be installed, instead of that for the target platform.
 
 The argument can be either a string with the name of the JLL package or a

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -351,6 +351,8 @@ function setup_workspace(build_path::AbstractString, sources::Vector,
     metadir = joinpath(workspace, "metadir")
     mkpath.((srcdir, target_destdir, host_destdir, metadir))
     # Create the symlink /workspace/destdir -> /workspace/TARGET_TRIPLET/destdir
+    # Necessary for compatibility with recipes that hardcode `/workspace/destdir` in them,
+    # as well as `.pc` files that contain absolute paths to `/workspace/destdir/...`
     symlink("$(triplet(target_platform))/destdir", joinpath(workspace, "destdir"))
 
     # Setup all sources

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -96,7 +96,7 @@ using JSON
                 mkpath(workspace)
                 prefix = @test_logs(
                     (:info, r"^Copying"), (:info, r"^Copying"), (:info, r"^Copying"), (:info, r"^Copying"), (:info, r"^Cloning"),
-                    setup_workspace(workspace, [sfs, sds_follow, sds_nofollow, sds_target, sgs]; verbose=true)
+                    setup_workspace(workspace, [sfs, sds_follow, sds_nofollow, sds_target, sgs], HostPlatform(); verbose=true)
                 )
                 @test Set(readdir(joinpath(prefix.path, "srcdir"))) == Set(
                     ["ARCHDefs", "file-source.tar.gz", "patches_follow", "patches_nofollow", "ds_unpack_target"]


### PR DESCRIPTION
Main changes:

* we now have two "prefixes", one for the target and one for the host.  To
  implement this,
  * `setup_workspace` takes in input the platforms of the target and the host,
    and it creates the symlink
    `/workspace/destdir` -> `/workspace/TARGET_TRIPLET/destdir`
  * the user will call `setup_dependencies` twice, once for the host and once
    for the target
* a new helper function `destdir(prefix, platform)` gives consistently the path
  to the destdir for the given platform within the given prefix
* added relevant environment variables `host_*dir` in the runners, and add
  `host_bindir` to the `PATH`
* added `is_host_dependency`, `is_target_dependency`, `is_build_dependency`,
  `is_runtime_dependency` functions which are _very_ useful to filter
  dependencies in different situations: as we add more and more of these
  `AbstractDependency` types, there are multiple types matching each trait and
  it's hard to consistently list all of them in all places

CC: @vchuravy.  Fix #37