### PR TITLE
More flexible skipping of C++ string ABIs expansion

### DIFF
--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -682,7 +682,7 @@ function expand_gfortran_versions(ps::Vector{<:Platform})
 end
 
 """
-    expand_cxxstring_abis(p::AbstractPlatform; skip_freebsd_macos::Bool=true)
+    expand_cxxstring_abis(p::AbstractPlatform; skip=Sys.isbsd)
 
 Given a `Platform`, returns an array of `Platforms` with a spread of identical
 entries with the exception of the `cxxstring_abi` tag within the `Platform`
@@ -690,13 +690,14 @@ object.  This is used to take, for example, a list of supported platforms and
 expand them to include multiple GCC versions for the purposes of ABI matching.
 
 If the given `Platform` already specifies a `cxxstring_abi` (as opposed to
-`nothing`) only that `Platform` is returned.  If `skip_freebsd_macos` is
-`true`, FreeBSD and MacOS platforms are not expanded, due to their lack of a
+`nothing`) only that `Platform` is returned.  If `skip` is a function for which
+`skip(platform)` evaluates to `true`, the given platform is not expanded.  By
+default FreeBSD and macOS platforms are skipped, due to their lack of a
 dependence on `libstdc++` and not needing this compatibility shim.
 """
-function expand_cxxstring_abis(platform::AbstractPlatform; skip_freebsd_macos::Bool=true)
+function expand_cxxstring_abis(platform::AbstractPlatform; skip=Sys.isbsd)
     # If this platform cannot/should not be expanded, then exit out fast here.
-    if cxxstring_abi(platform) !== nothing || (skip_freebsd_macos && Sys.isbsd(platform))
+    if cxxstring_abi(platform) !== nothing || skip(platform)
         return [platform]
     end
 

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -29,11 +29,16 @@ using BinaryBuilderBase
         Platform("x86_64", "freebsd"),
         Platform("x86_64", "macos"),
     ]
-    @test expand_cxxstring_abis([Platform("x86_64", "freebsd"), Platform("x86_64", "macos")]; skip_freebsd_macos=false) == [
+    @test expand_cxxstring_abis([Platform("x86_64", "freebsd"), Platform("x86_64", "macos")]; skip=_->false) == [
         Platform("x86_64", "freebsd"; cxxstring_abi="cxx03"),
         Platform("x86_64", "freebsd"; cxxstring_abi="cxx11"),
         Platform("x86_64", "macos"; cxxstring_abi="cxx03"),
         Platform("x86_64", "macos"; cxxstring_abi="cxx11"),
+    ]
+    @test expand_cxxstring_abis([Platform("x86_64", "freebsd"), Platform("x86_64", "linux")]; skip=Sys.islinux) == [
+        Platform("x86_64", "freebsd"; cxxstring_abi="cxx03"),
+        Platform("x86_64", "freebsd"; cxxstring_abi="cxx11"),
+        Platform("x86_64", "linux"),
     ]
     @test expand_cxxstring_abis([Platform("i686", "linux"; cxxstring_abi="cxx11")]) ==
         [Platform("i686", "linux"; cxxstring_abi="cxx11")]


### PR DESCRIPTION
Let the user pass a custom function to selectively skip expansion

I believe this is also better than hardcoding FreeBSD and macOS in the name of the argument.