### PR TITLE
Add `experimental` kwarg to `supported_platforms()`

### DIFF
--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -623,7 +623,8 @@ islin(x) = typeof(x) == Linux
 supported_platforms(exclude=islin)
 ```
 """
-function supported_platforms(;exclude::Union{Vector{<:Platform},Function}=x->false)
+function supported_platforms(;exclude::Union{Vector{<:Platform},Function}=x->false,
+                              experimental::Bool=false)
     exclude_platforms!(platforms, exclude::Function) = filter(!exclude, platforms)
     exclude_platforms!(platforms, exclude::Vector{<:Platform}) = filter!(!in(exclude), platforms)
     standard_platforms = [
@@ -650,6 +651,15 @@ function supported_platforms(;exclude::Union{Vector{<:Platform},Function}=x->fal
         Platform("i686", "windows"),
         Platform("x86_64", "windows"),
     ]
+
+    # We have experimental support for some platforms, allow easily including them
+    if experimental
+        append!(standard_platforms, [
+            Platform("aarch64", "macos"),
+            Platform("armv6l", "linux"),
+            Platform("armv6l", "linux"; libc="musl"),
+        ])
+    end
     return exclude_platforms!(standard_platforms,exclude)
 end
 

--- a/test/compat.jl
+++ b/test/compat.jl
@@ -44,7 +44,7 @@ using BinaryBuilderBase: download_verify, list_tarball_files
         @test_throws ErrorException download_verify("https://github.com/not_a_file", "0"^64, joinpath(dir, "blah"))
 
         # Test that a bad hash logs a message and fails
-        @test_logs (:error, r"Hash Mismatch") @test_throws ErrorException begin
+        @test_logs (:error, r"Hash Mismatch") match_mode=:any @test_throws ErrorException begin
             download_verify("https://github.com/staticfloat/small_bin/raw/master/socrates.tar.xz", "0"^64, joinpath(dir, "blah2"))
         end
     end


### PR DESCRIPTION
This will make it easier to have base julia deps always build for the
widest possible set of platforms, while letting the rest of Yggdrasil
continue to live in blissful ignorance