### PR TITLE
Handle existing files while downloading ourselves.

### DIFF
--- a/src/ArchiveUtils.jl
+++ b/src/ArchiveUtils.jl
@@ -127,6 +127,11 @@ function verify(path::AbstractString, hash::AbstractString; hash_path::AbstractS
 end
 
 function download_verify(url, hash, path)
+    if isfile(path)
+        verify(path, hash) && return
+        @warn "Verification of $(basename(path)) failed; redownloading"
+        rm(path)
+    end
     Downloads.download(url, path)
     verify(path, hash) || error("Verification failed")
 end


### PR DESCRIPTION
Seems more robust than relying on Downloads.jl not to redownload, and helps in the case that we can't even `HEAD` the URL (as, e.g., with NVIDIA's secure server; I just SCP the archives to the download server manually for those JLLs).