### PR TITLE
Mark currently broken tests as such

### DIFF
--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -67,11 +67,11 @@ end
             ap = @test_logs setup_dependencies(prefix, getpkg.(dependencies), platform)
             @test "libz." * platform_dlext(platform) in readdir(last(libdirs(Prefix(joinpath(dir, "destdir")))))
             @test "zlib.h" in readdir(joinpath(dir, "destdir", "include"))
-            @test readdir(joinpath(dir, "destdir", "logs")) == ["Zlib.log.gz"]
+            @test_broken readdir(joinpath(dir, "destdir", "logs")) == ["Zlib.log.gz"]
 
             # Make sure the directories are emptied by `cleanup_dependencies`
             @test_nowarn cleanup_dependencies(prefix, ap)
-            @test readdir(joinpath(dir, "destdir", "include")) == []
+            @test_broken readdir(joinpath(dir, "destdir", "include")) == []
             @test readdir(joinpath(dir, "destdir", "logs")) == []
         end
 
@@ -85,7 +85,7 @@ end
             @test_logs (:warn, r"Dependency LibOSXUnwind_jll does not have a mapping for artifact LibOSXUnwind for platform") begin
                 setup_dependencies(prefix, getpkg.(dependencies), platform)
             end
-            @test "destdir" ∉ readdir(joinpath(dir))
+            @test_broken "destdir" ∉ readdir(joinpath(dir))
         end
 
         # Test setup of dependencies that depend on the Julia version


### PR DESCRIPTION
All JLL packages formally depends on `Pkg`, including the new ones that don't
actually load it.  However, in Julia nightly `Pkg` has an indirect dependency on
`LibCURL_jll` and `MozillaCACerts_jll`, which means that `installed_jlls` in
`setup_dependencies` _always_ contains these two packages, see
https://github.com/JuliaPackaging/BinaryBuilderBase.jl/blob/c4c7c838ad8cc2b134d0a46551497ef92f9a9e68/src/Prefix.jl#L411-L414

This changeset is to temporarily ignore the failing tests, for the sake of
keeping the test suite working, until this is properly resolved.

CC: @staticfloat 