### PR TITLE
Limit `libgfortran` expansion on `aarch64-apple-darwin`

### DIFF
--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -19,6 +19,12 @@ using BinaryBuilderBase
     ]
     @test expand_gfortran_versions([Platform("x86_64", "freebsd"; libgfortran_version=v"3")]) ==
         [Platform("x86_64", "freebsd"; libgfortran_version=v"3")]
+    @test expand_gfortran_versions([Platform("x86_64", "macos"), Platform("aarch64", "macos")]) == [
+        Platform("x86_64",  "macos"; libgfortran_version=v"3"),
+        Platform("x86_64",  "macos"; libgfortran_version=v"4"),
+        Platform("x86_64",  "macos"; libgfortran_version=v"5"),
+        Platform("aarch64", "macos"; libgfortran_version=v"5"),
+    ]
 
     # expand_cxxstring_abis
     @test expand_cxxstring_abis(Platform("x86_64", "linux"; libc="musl")) == [


### PR DESCRIPTION
Because we only have GCC 11 available, we need to ensure that we only
expand to `libgfortran5` on aarch64 MacOS