### PR TITLE
Switch platform arch i686 to use -march=pentium4

### DIFF
--- a/src/Platforms.jl
+++ b/src/Platforms.jl
@@ -87,7 +87,7 @@ const ARCHITECTURE_FLAGS = Dict(
     # Many compiler flags are the same across clang and gcc, store those in "common"
     "common" => Dict(
         "i686" => Dict(
-            "i686" => ["-march=i686", "-mtune=generic"],
+            "pentium4" => ["-march=pentium4", "-mtune=generic"],
             "prescott" => ["-march=prescott", "-mtune=prescott"],
         ),
         "x86_64" => Dict(

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -65,7 +65,7 @@ using BinaryBuilderBase
         # Platform("armv6l", "linux"; libc="glibc", call_abi="eabihf", march="arm1176jzfs"),
         Platform("armv7l", "linux"; libc="glibc", call_abi="eabihf", march="armv7l"),
         Platform("armv7l", "linux"; libc="glibc", call_abi="eabihf", march="neonvfpv4"),
-        Platform("i686", "linux"; libc="glibc", march="i686"),
+        Platform("i686", "linux"; libc="glibc", march="pentium4"),
         Platform("i686", "linux"; libc="glibc", march="prescott"),
         Platform("powerpc64le", "linux"; libc="glibc", march="power8"),
         Platform("x86_64", "linux"; libc="glibc", march="avx"),


### PR DESCRIPTION
Before, we used -march=i686, but that does not include MMX, SSE, SSE2 support,
which Julia requires. By switching to pentium4 as base level, better optimized
code can be generated, and also linking against libjulia then work for
32bit binaries without extra compiler flags.

Alternative to https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/960, see also the discussion there.

At least I hope this is a viable alternative -- I didn't test it thoroughly to verify.