### PR TITLE
[Travis] Do not run full test suite without SquashFS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ jobs:
         - BINARYBUILDER_RUNNER=unprivileged
         - BINARYBUILDER_USE_SQUASHFS=false
         - JULIA_PKG_SERVER=
-        - BINARYBUILDER_FULL_SHARD_TEST=true
         - BINARYBUILDER_AUTOMATIC_APPLE=true
 
     # Add a job that uses the docker builder with unpacked shards
@@ -58,7 +57,6 @@ jobs:
         - BINARYBUILDER_RUNNER=docker
         - BINARYBUILDER_USE_SQUASHFS=false
         - JULIA_PKG_SERVER=
-        - BINARYBUILDER_FULL_SHARD_TEST=true
         - BINARYBUILDER_AUTOMATIC_APPLE=true
 
     - stage: "Documentation"


### PR DESCRIPTION
Restoring the cache seems to take forever.  We could use `travis_wait`
to avoid the 10-minute timeout, but it just takes too long.