### PR TITLE
[Runner] Move target wrappers to `/opt/bin/$(triplet(platform))`

### DIFF
--- a/src/BinaryBuilderBase.jl
+++ b/src/BinaryBuilderBase.jl
@@ -33,6 +33,7 @@ include("Products.jl")
 include("Platforms.jl")
 
 include("Runner.jl")
+include("BuildToolchains.jl")
 include("Rootfs.jl")
 include("squashfs_utils.jl")
 include("UserNSRunner.jl")

--- a/src/BuildToolchains.jl
+++ b/src/BuildToolchains.jl
@@ -1,0 +1,212 @@
+abstract type AbstractBuildToolchain{C} end
+
+struct CMake{C} <: AbstractBuildToolchain{C} end
+struct Meson{C} <: AbstractBuildToolchain{C} end
+
+c_compiler(::AbstractBuildToolchain{:clang}) = "clang"
+cxx_compiler(::AbstractBuildToolchain{:clang}) = "clang++"
+c_compiler(::AbstractBuildToolchain{:gcc}) = "gcc"
+cxx_compiler(::AbstractBuildToolchain{:gcc}) = "g++"
+fortran_compiler(::AbstractBuildToolchain) = "gfortran"
+
+function cmake_arch(p::AbstractPlatform)
+    if arch(p) == "powerpc64le"
+        return "ppc64le"
+    else
+        return arch(p)
+    end
+end
+
+function cmake_os(p::AbstractPlatform)
+    if Sys.islinux(p)
+        return "Linux"
+    elseif Sys.isfreebsd(p)
+        return "FreeBSD"
+    elseif Sys.isapple(p)
+        return "Darwin"
+    elseif Sys.iswindows(p)
+        return "Windows"
+    end
+end
+
+function toolchain_file(bt::CMake, p::AbstractPlatform)
+    target = triplet(p)
+    aatarget = aatriplet(p)
+
+    if Sys.isapple(p)
+        darwin_ver = something(os_version(p), v"14.5.0")
+        maj_ver = darwin_ver.major
+        min_ver = darwin_ver.minor
+        return """
+        # CMake toolchain file for $(c_compiler(bt)) running on $(target)
+        set(CMAKE_SYSTEM_NAME $(cmake_os(p)))
+        set(CMAKE_SYSTEM_PROCESSOR $(cmake_arch(p)))
+        set(CMAKE_SYSTEM_VERSION $(maj_ver).$(min_ver))
+        set(DARWIN_MAJOR_VERSION $(maj_ver))
+        set(DARWIN_MINOR_VERSION $(min_ver))
+
+        # Enable rpath support
+        set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
+
+        set(CMAKE_SYSROOT /opt/$(aatarget)/$(aatarget)/sys-root)
+        set(CMAKE_SYSTEM_FRAMEWORK_PATH
+            \${CMAKE_SYSROOT}/System/Library/Frameworks
+            \${CMAKE_SYSROOT}/System/Library/PrivateFrameworks
+        )
+        set(CMAKE_INSTALL_PREFIX \$ENV{prefix})
+
+        set(CMAKE_C_COMPILER   /opt/bin/$(target)/$(c_compiler(bt)))
+        set(CMAKE_CXX_COMPILER /opt/bin/$(target)/$(cxx_compiler(bt)))
+        set(CMAKE_Fortran_COMPILER /opt/bin/$(target)/$(fortran_compiler(bt)))
+
+        set(CMAKE_LINKER  /opt/bin/$(target)/$(aatarget)-ld)
+        set(CMAKE_OBJCOPY /opt/bin/$(target)/$(aatarget)-objcopy)
+
+        set(CMAKE_AR     /opt/bin/$(target)/$(aatarget)-ar)
+        set(CMAKE_NM     /opt/bin/$(target)/$(aatarget)-nm)
+        set(CMAKE_RANLIB /opt/bin/$(target)/$(aatarget)-ranlib)
+
+        if( \$ENV{CC} MATCHES ccache )
+            set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+        endif()
+        """
+    else
+        return """
+        # CMake toolchain file for $(c_compiler(bt)) running on $(target)
+        set(CMAKE_SYSTEM_NAME $(cmake_os(p)))
+        set(CMAKE_SYSTEM_PROCESSOR $(cmake_arch(p)))
+
+        set(CMAKE_SYSROOT /opt/$(aatarget)/$(aatarget)/sys-root/)
+        set(CMAKE_INSTALL_PREFIX \$ENV{prefix})
+
+        set(CMAKE_C_COMPILER   /opt/bin/$(target)/$(c_compiler(bt)))
+        set(CMAKE_CXX_COMPILER /opt/bin/$(target)/$(cxx_compiler(bt)))
+        set(CMAKE_Fortran_COMPILER /opt/bin/$(target)/$(fortran_compiler(bt)))
+
+        set(CMAKE_LINKER  /opt/bin/$(target)/$(aatarget)-ld)
+        set(CMAKE_OBJCOPY /opt/bin/$(target)/$(aatarget)-objcopy)
+
+        set(CMAKE_AR     /opt/bin/$(target)/$(aatarget)-ar)
+        set(CMAKE_NM     /opt/bin/$(target)/$(aatarget)-nm)
+        set(CMAKE_RANLIB /opt/bin/$(target)/$(aatarget)-ranlib)
+
+        if( \$ENV{CC} MATCHES ccache )
+            set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+        endif()
+        """
+    end
+end
+
+function meson_c_link_args(p::AbstractPlatform)
+    if arch(p) == "powerpc64le" && Sys.islinux(p)
+        return "'-Wl,-rpath-link,/workspace/destdir/lib64'"
+    else
+        return ""
+    end
+end
+meson_cxx_link_args(p::AbstractPlatform) = meson_c_link_args(p)
+meson_fortran_link_args(p::AbstractPlatform) = meson_c_link_args(p)
+
+# We can run native programs only on
+# * i686-linux-gnu
+# * x86_64-linux-gnu
+# * x86_64-linux-musl
+function meson_is_foreign(p::AbstractPlatform)
+    if Sys.islinux(p) && proc_family(p) == "intel" && (libc(p) == "glibc" || (libc(p) == "musl" && arch(p) == "x86_64"))
+        # Better to explicitly return the string we expect rather than
+        # relying on the representation of the boolean values (even though
+        # the result is the same)
+        return "false"
+    else
+        return "true"
+    end
+end
+
+# https://mesonbuild.com/Reference-tables.html#operating-system-names
+meson_system(p::AbstractPlatform) = lowercase(cmake_os(p))
+
+# https://github.com/mesonbuild/meson/blob/6e39dcad2fbd8d1c739e262b0e7b7d901cf1ce08/mesonbuild/environment.py#L412-L440
+meson_cpu(p::AbstractPlatform) = cmake_arch(p)
+
+# https://mesonbuild.com/Reference-tables.html#cpu-families
+function meson_cpu_family(p::AbstractPlatform)
+    if arch(p) == "powerpc64le"
+        return "ppc64"
+    elseif arch(p) == "i686"
+        return "x86"
+    elseif arch(p) == "x86_64"
+        return "x86_64"
+    elseif arch(p) == "aarch64"
+        return "aarch64"
+    elseif startswith(arch(p), "arm")
+        return "arm"
+    end
+end
+
+function toolchain_file(bt::Meson, p::AbstractPlatform)
+    target = triplet(p)
+    aatarget = aatriplet(p)
+
+    return """
+    [binaries]
+    c = '/opt/bin/$(target)/$(aatarget)-$(c_compiler(bt))'
+    cpp = '/opt/bin/$(target)/$(aatarget)-$(c_compiler(bt))'
+    fortran = '/opt/bin/$(target)/$(aatarget)-$(fortran_compiler(bt))'
+    objc = '/opt/bin/$(target)/$(aatarget)-objc'
+    ar = '/opt/bin/$(target)/$(aatarget)-ar'
+    ld = '/opt/bin/$(target)/$(aatarget)-ld'
+    nm = '/opt/bin/$(target)/$(aatarget)-nm'
+    strip = '/opt/bin/$(target)/$(aatarget)-strip'
+    pkgconfig = '/usr/bin/pkg-config'
+
+    [properties]
+    c_args = []
+    cpp_args = []
+    fortran_args = []
+    c_link_args = [$(meson_c_link_args(p))]
+    cpp_link_args = [$(meson_cxx_link_args(p))]
+    fortran_link_args = [$(meson_fortran_link_args(p))]
+    needs_exe_wrapper = $(meson_is_foreign(p))
+
+    [build_machine]
+    system = 'linux'
+    cpu_family = 'x86_64'
+    cpu = 'x86_64'
+    endian = 'little'
+
+    [host_machine]
+    system = '$(meson_system(p))'
+    cpu_family = '$(meson_cpu_family(p))'
+    cpu = '$(meson_cpu(p))'
+    endian = 'little'
+
+    [paths]
+    prefix = '/workspace/destdir'
+    """
+end
+
+function generate_toolchain_files!(platform::AbstractPlatform;
+                                   toolchains_path::AbstractString,
+                                   host_platform::AbstractPlatform = default_host_platform,
+                                   )
+
+    # Generate the files fot bot the host and the target platforms
+    for p in unique((platform, host_platform))
+        dir = joinpath(toolchains_path, triplet(p))
+        mkpath(dir)
+
+        write(joinpath(dir, "$(aatriplet(p))_clang.cmake"), toolchain_file(CMake{:clang}(), p))
+        write(joinpath(dir, "$(aatriplet(p))_gcc.cmake"), toolchain_file(CMake{:gcc}(), p))
+        write(joinpath(dir, "$(aatriplet(p))_clang.meson"), toolchain_file(Meson{:clang}(), p))
+        write(joinpath(dir, "$(aatriplet(p))_gcc.meson"), toolchain_file(Meson{:gcc}(), p))
+
+        # On FreeBSD and MacOS we actually want to default to clang, otherwise gcc
+        if Sys.isbsd(p)
+            symlink("$(aatriplet(p))_clang.cmake", joinpath(dir, "$(aatriplet(p)).cmake"))
+            symlink("$(aatriplet(p))_clang.meson", joinpath(dir, "$(aatriplet(p)).meson"))
+        else
+            symlink("$(aatriplet(p))_gcc.cmake", joinpath(dir, "$(aatriplet(p)).cmake"))
+            symlink("$(aatriplet(p))_gcc.meson", joinpath(dir, "$(aatriplet(p)).meson"))
+        end
+    end
+end

--- a/src/DockerRunner.jl
+++ b/src/DockerRunner.jl
@@ -74,6 +74,7 @@ function DockerRunner(workspace_root::String;
                       extra_env=Dict{String, String}(),
                       verbose::Bool = false,
                       compiler_wrapper_path::String = mktempdir(),
+                      toolchains_path::String = mktempdir(),
                       src_name::AbstractString = "",
                       shards = nothing,
                       kwargs...)
@@ -90,6 +91,10 @@ function DockerRunner(workspace_root::String;
     # JIT out some compiler wrappers, add it to our mounts
     generate_compiler_wrappers!(platform; bin_path=compiler_wrapper_path, extract_kwargs(kwargs, (:compilers,:allow_unsafe_flags,:lock_microarchitecture))...)
     push!(workspaces, compiler_wrapper_path => "/opt/bin")
+
+    # Generate CMake and Meson files
+    generate_toolchain_files!(platform; toolchains_path=toolchains_path)
+    push!(workspaces, toolchains_path => "/opt/toolchains")
 
     # the workspace_root is always a workspace, and we always mount it first
     insert!(workspaces, 1, workspace_root => "/workspace")

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -15,7 +15,7 @@ struct CompilerShard
     # Things like Platform("x86_64", "windows"; libgfortran_version=v"3")
     target::Union{Nothing,Platform}
 
-    # Usually `Platform("x86_64", "linux"; libc="musl")`
+    # Usually `default_host_platform`
     host::AbstractPlatform
     
     # :unpacked or :squashfs.  Possibly more in the future.
@@ -332,7 +332,7 @@ function macos_sdk_already_installed()
     css = all_compiler_shards()
     macos_artifact_names = artifact_name.(filter(cs -> cs.target !== nothing && Sys.isapple(cs.target), css))
 
-    host_platform = Platform("x86_64", "linux"; libc="musl")
+    host_platform = default_host_platform
     artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
     macos_artifact_hashes = artifact_hash.(macos_artifact_names, artifacts_toml; platform=host_platform)
 
@@ -497,8 +497,8 @@ function choose_shards(p::AbstractPlatform;
             preferred_llvm_version::VersionNumber = getversion(LLVM_builds[end]),
         )
 
-    # Our host platform is x86_64-linux-musl
-    host_platform = Platform("x86_64", "linux"; libc="musl")
+    # Our host platform is x86_64-linux-musl-cxx11
+    host_platform = default_host_platform
 
     function find_shard(name, version, archive_type; target = nothing)
         # Ugly hack alert!  Because GCC 11 has somehow broken C++, we pair GCC 9 with GCC 11 on MacOS
@@ -606,7 +606,7 @@ function choose_shards(p::AbstractPlatform;
 end
 
 # XXX: we want AnyPlatform to look like `x86_64-linux-musl` in the build environment.
-choose_shards(::AnyPlatform; kwargs...) = choose_shards(Platform("x86_64", "linux"; libc="musl"); kwargs...)
+choose_shards(::AnyPlatform; kwargs...) = choose_shards(default_host_platform; kwargs...)
 
 """
     supported_platforms(;exclude::Union{Vector{<:Platform},Function}=x->false)
@@ -874,7 +874,7 @@ function download_all_artifacts(; verbose::Bool = false)
         artifacts_toml;
         include_lazy=true,
         verbose=verbose,
-        platform=Platform("x86_64", "linux"; libc="musl"),
+        platform=default_host_platform,
     )
 end
 

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -878,10 +878,10 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
         "LLVM_HOST_TARGET" => host_target,
 
         # Let the user parameterize their scripts for toolchain locations
-        "CMAKE_HOST_TOOLCHAIN" => "/opt/$(host_target)/$(host_target).cmake",
-        "CMAKE_TARGET_TOOLCHAIN" => "/opt/$(target)/$(target).cmake",
-        "MESON_HOST_TOOLCHAIN" => "/opt/$(host_target)/$(host_target).meson",
-        "MESON_TARGET_TOOLCHAIN" => "/opt/$(target)/$(target).meson",
+        "CMAKE_HOST_TOOLCHAIN" => "/opt/toolchains/$(triplet(host_platform))/$(host_target).cmake",
+        "CMAKE_TARGET_TOOLCHAIN" => "/opt/toolchains/$(triplet(platform))/$(target).cmake",
+        "MESON_HOST_TOOLCHAIN" => "/opt/toolchains/$(triplet(host_platform))/$(host_target).meson",
+        "MESON_TARGET_TOOLCHAIN" => "/opt/toolchains/$(triplet(platform))/$(target).meson",
 
         # We should always be looking for packages already in the prefix
         "PKG_CONFIG_PATH" => "$(prefix)/lib/pkgconfig:$(prefix)/lib64/pkgconfig:$(prefix)/share/pkgconfig",

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -1,6 +1,11 @@
 import Base: strip
 abstract type Runner; end
 
+# Host platform _must_ match the C++ string ABI of the binaries we get from the
+# repositories.  Note: when preferred_gcc_version=v"4" we can't really build for
+# that C++ string ABI :-(
+const default_host_platform = Platform("x86_64", "linux"; libc="musl", cxxstring_abi="cxx11")
+
 function nbits(p::AbstractPlatform)
     if arch(p) in ("i686", "armv6l", "armv7l")
         return 32
@@ -33,11 +38,11 @@ function aatriplet(p::AbstractPlatform)
     return t
 end
 # XXX: we want AnyPlatform to look like `x86_64-linux-musl` in the build environment.
-aatriplet(p::AnyPlatform) = aatriplet(Platform("x86_64", "linux"; libc="musl"))
+aatriplet(p::AnyPlatform) = aatriplet(default_host_platform)
 
 """
     generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::AbstractString,
-                                host_platform::AbstractPlatform = Platform("x86_64", "linux"; libc="musl"),
+                                host_platform::AbstractPlatform = $(repr(default_host_platform)),
                                 compilers::Vector{Symbol} = [:c],
                                 allow_unsafe_flags::Bool = false,
                                 lock_microarchitecture::Bool = true)
@@ -51,7 +56,7 @@ difficult to override, as the flags embedded in these wrappers are absolutely ne
 and even simple programs will not compile without them.
 """
 function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::AbstractString,
-                                     host_platform::AbstractPlatform = Platform("x86_64", "linux"; libc="musl"),
+                                     host_platform::AbstractPlatform = default_host_platform,
                                      compilers::Vector{Symbol} = [:c],
                                      allow_unsafe_flags::Bool = false,
                                      lock_microarchitecture::Bool = true,
@@ -68,31 +73,6 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
 
     target = aatriplet(platform)
     host_target = aatriplet(host_platform)
-
-
-    # If the ABI-agnostic triplets of the target and the host platform are the
-    # same, then we have to be very careful: we can't have distinct wrappers, so
-    # we have to be sure that their ABIs are consistent and that we're correctly
-    # writing the wrappers for the target platform.  In  particular, what we care
-    # about with regard to the wrappers is the C++ string ABI:
-    #   * they are equal: this is fine
-    #   * they're different and the host has a preference for the C++ string ABI:
-    #     we can't deal with this situation as the host wrappers will be always
-    #     overwritten, then error out
-    #   * in all other cases we don't do anything here, below we'll let
-    #     the host wrappers be overwritten by the wrappers for the target
-    if target == host_target
-        target_cxxabi = cxxstring_abi(platform)
-        host_cxxabi   = cxxstring_abi(host_platform)
-        if target_cxxabi !== host_cxxabi
-            if host_cxxabi !== nothing
-                # This is a very unlikely situation as ideally the host
-                # shouldn't have particular preferences for the ABI, thus in
-                # practice we should never reach this.
-                error("Incompatible C++ string ABIs between the host and target platforms")
-            end
-        end
-    end
 
     function wrapper(io::IO,
                      prog::String;
@@ -579,14 +559,13 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     end
 
     function write_wrapper(wrappergen, p, fname)
-        open(io -> Base.invokelatest(wrappergen, io, p), joinpath(bin_path, fname), "w")
-        chmod(joinpath(bin_path, fname), 0o775)
+        file_path = joinpath(bin_path, triplet(p), fname)
+        mkpath(dirname(file_path))
+        open(io -> Base.invokelatest(wrappergen, io, p), file_path, "w")
+        chmod(file_path, 0o775)
     end
 
-    ## Generate compiler wrappers for both our host and our target.  In
-    ## particular, we write the wrapper for the target after those for the host,
-    ## to override host-specific ABI in case this is incompatible with that of
-    ## the target
+    ## Generate compiler wrappers for both our host and our target.
     for p in unique((host_platform, platform))
         t = aatriplet(p)
 
@@ -693,7 +672,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     end
     # Create symlinks for default compiler invocations, invoke target toolchain
     for tool in default_tools
-        symlink("$(target)-$(tool)", joinpath(bin_path, tool))
+        symlink("$(target)-$(tool)", joinpath(bin_path, triplet(platform), tool))
     end
 end
 
@@ -722,7 +701,7 @@ defined target architecture.  Examples of things set are `PATH`, `CC`,
 `RANLIB`, as well as nonstandard things like `target`.
 """
 function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
-                       host_platform = Platform("x86_64", "linux"; libc="musl"),
+                       host_platform = default_host_platform,
                        bootstrap::Bool=!isempty(bootstrap_list),
                        verbose::Bool = false)
     global use_ccache
@@ -846,9 +825,11 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
     merge!(mapping, Dict(
         "PATH" => join((
             # First things first, our compiler wrappers trump all
-            "/opt/bin",
+            "/opt/bin/$(triplet(platform))",
             # Allow users to use things like x86_64-linux-gnu here
             "/opt/$(target)/bin",
+            # Also wrappers for the host
+            "/opt/bin/$(triplet(host_platform))",
             "/opt/$(host_target)/bin",
             # Default alpine PATH
             mapping["PATH"],
@@ -925,17 +906,21 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
     # so we set all the environment variables that we've seen them called
     # and hope for the best.
     for host_map in (tool -> "HOST$(tool)", tool -> "$(tool)_FOR_BUILD", tool -> "BUILD_$(tool)", tool -> "$(tool)_BUILD")
+        # Use full path to avoid collisions when the target is similar to the
+        # host (e.g., `x86_64-linux-musl-cxx03` and `x86_64-linux-musl-cxx11`)
+        host_bin_dir = "/opt/bin/$(triplet(host_platform))"
+
         # First, do the simple tools where it's just X => $(host_target)-x:
         for tool in ("AR", "AS", "LD", "LIPO", "NM", "RANLIB", "READELF", "OBJCOPY", "OBJDUMP", "STRIP")
-            mapping[host_map(tool)] = "$(host_target)-$(lowercase(tool))"
+            mapping[host_map(tool)] = "$(host_bin_dir)/$(host_target)-$(lowercase(tool))"
         end
 
         # Next, the more custom tool mappings
         for (env_name, tool) in (
-            "CC" => "$(host_target)-gcc",
-            "CXX" => "$(host_target)-g++",
+            "CC" => "$(host_bin_dir)/$(host_target)-gcc",
+            "CXX" => "$(host_bin_dir)/$(host_target)-g++",
             "DSYMUTIL" => "llvm-dsymutil",
-            "FC" => "$(host_target)-gfortran"
+            "FC" => "$(host_bin_dir)/$(host_target)-gfortran"
            )
             mapping[host_map(env_name)] = tool
         end

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -328,7 +328,7 @@ function probe_unprivileged_containers(;verbose::Bool=false)
 
     function test_sandbox(; verbose=verbose, workspace_tmpdir=false, map_shard=false)
         # Choose and prepare our shards
-        shards = choose_shards(Platform("x86_64", "linux"; libc="musl"))
+        shards = choose_shards(default_host_platform)
         root_shard = first(shards)
         other_shard = last(shards)
 

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -26,6 +26,7 @@ function UserNSRunner(workspace_root::String;
                       extra_env=Dict{String, String}(),
                       verbose::Bool = false,
                       compiler_wrapper_path::String = mktempdir(),
+                      toolchains_path::String = mktempdir(),
                       src_name::AbstractString = "",
                       shards = nothing,
                       kwargs...)
@@ -45,6 +46,10 @@ function UserNSRunner(workspace_root::String;
     # JIT out some compiler wrappers, add it to our mounts
     generate_compiler_wrappers!(platform; bin_path=compiler_wrapper_path, extract_kwargs(kwargs, (:compilers,:allow_unsafe_flags,:lock_microarchitecture))...)
     push!(workspaces, compiler_wrapper_path => "/opt/bin")
+
+    # Generate CMake and Meson files
+    generate_toolchain_files!(platform; toolchains_path=toolchains_path)
+    push!(workspaces, toolchains_path => "/opt/toolchains")
 
     # the workspace_root is always a workspace, and we always mount it first
     insert!(workspaces, 1, workspace_root => "/workspace")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,4 +59,4 @@ end
 
 # XXX: we want the AnyPlatform to look like `x86_64-linux-musl`,
 get_concrete_platform(::AnyPlatform, shards::Vector{CompilerShard}) =
-    get_concrete_platform(Platform("x86_64", "linux"; libc="musl"), shards)
+    get_concrete_platform(default_host_platform, shards)

--- a/test/platforms.jl
+++ b/test/platforms.jl
@@ -2,7 +2,7 @@ using Test
 using Base.BinaryPlatforms
 using BinaryBuilderBase
 using BinaryBuilderBase: abi_agnostic, get_concrete_platform, march, platform_dlext, platform_exeext,
-                         nbits, proc_family
+                         nbits, proc_family, default_host_platform
 
 @testset "Supported Platforms" begin
     all = supported_platforms()
@@ -46,13 +46,13 @@ end
             preferred_gcc_version = v"7",
             preferred_llvm_version = v"9",
         ) == get_concrete_platform(
-            Platform("x86_64", "linux"; libc="musl");
+            default_host_platform;
             compilers = [:c],
             preferred_gcc_version = v"7",
             preferred_llvm_version = v"9",
         )
-    @test BinaryBuilderBase.choose_shards(AnyPlatform()) == BinaryBuilderBase.choose_shards(Platform("x86_64", "linux"; libc="musl"))
-    @test BinaryBuilderBase.aatriplet(AnyPlatform()) == BinaryBuilderBase.aatriplet(Platform("x86_64", "linux"; libc="musl"))
+    @test BinaryBuilderBase.choose_shards(AnyPlatform()) == BinaryBuilderBase.choose_shards(default_host_platform)
+    @test BinaryBuilderBase.aatriplet(AnyPlatform()) == BinaryBuilderBase.aatriplet(default_host_platform)
 end
 
 @testset "Target properties" begin


### PR DESCRIPTION
This allows us to better discriminate between the wrappers for the host and
those for the target, important when the two platforms are similar (e.g., they
differ only by the C++ string ABI).

With this PR I can build https://github.com/JuliaPackaging/Yggdrasil/pull/2157 for `x86_64-linux-musl-cxx03` without any change.  Fix #81.