### PR TITLE
Roll `Rust` build back to `v1.43`

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2160,310 +2160,310 @@ os = "linux"
     sha256 = "f4d1a5dcb111ee844a9eaa679540b88cc7395da81d406f1024209cf4bf77df10"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2020.8.19/Rootfs.v2020.8.19.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustBase.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustBase.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "ca71a2430161820505e249422dd16b6a4c97d2fe"
+git-tree-sha1 = "bcd3deb4047a5fdae6abf9808da90e7de1be3924"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustBase.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "e4f82676f93ee6879e2a0fb989bcda9cddc9dd9381e10a909d4068c22445c083"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.48.0/RustBase.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustBase.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "bb832c8e266f9e2b80137662c64da5a060895711d61468cc02134f08dd45675a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.43.0/RustBase.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustBase.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustBase.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "149e283239445a4f273410520c51b881914c1baa"
+git-tree-sha1 = "dd295f16022f44a6e2a11659686210653b3dd734"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustBase.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "defbf0614e48f858794b18362f91fb4b4a20a09c1ee7d92e330c85359960d5d0"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.48.0/RustBase.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustBase.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "add2085c6cb4a5822b2796c1060b0ffeb05be381a8effaa4ce655da0bbe27fef"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.43.0/RustBase.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-aarch64-linux-gnu.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "1eb57f2014eb7ba6007d6931c2db33723e453d22"
+git-tree-sha1 = "679466147d4a4f83e448f0b64d8045178d3387d9"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-aarch64-linux-gnu.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "020a83ef9d9d4e3e882745587a567dbc782fcde1dc3454e7e7618bb81d7a4595"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-aarch64-linux-gnu.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "a1a80df576a306cade3c623b3b7a06a9350e69f35d8fba00d4f425ba6008ff00"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-aarch64-linux-gnu.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "27f647fc1362b80ec95abe87ee8986fa5b75be46"
+git-tree-sha1 = "16ab1df0afc72fa428040bda5ee51521390936a1"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-aarch64-linux-gnu.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "648237dea8228b1afe56b99f89f461d139eb0bb3d474f64c6f48c1351088a4f7"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-aarch64-linux-gnu.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "f4e3d1adb8944c745c29157b98b0d7c0b5061f990e5544716d171e9dd84310e4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-aarch64-linux-musl.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "0ae9fd19c5bfec8c4c5f26469613ac64b37c2f64"
+git-tree-sha1 = "30a1e761cdef918a3097dfb33de3b4bd405e4ea4"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-aarch64-linux-musl.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "5d5465e341ae93bd0324ef243a3e1806d082de0502f3a27568a5847a15efa971"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-aarch64-linux-musl.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "46b76ea4e5e3fc59028c8a4f2aa0e118fd3763cb573cc9d25f8d4d0346e97eed"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-aarch64-linux-musl.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "43263dfc572831b50eeb6112cacb91f00a51e6a0"
+git-tree-sha1 = "26b111ba5a0cf9f962e5903117948abb7b04425d"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-aarch64-linux-musl.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "eae23f6c30b94687d795f27087d64ab4f6201ad2fb00d2e5efca61a7d57d0ec6"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-aarch64-linux-musl.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "a5d872c32408a61c8e94529a94242dc8528cefa09a134ef517901c569a1ca77f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-armv7l-linux-gnueabihf.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "066767d417192551c6c09c2f634228b8fa737602"
+git-tree-sha1 = "39a97ffc947b02fca6e70b856aeaf422354ece8e"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-armv7l-linux-gnueabihf.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "715056f1612e9adf65f233ba28d1f652635b10318675c893a2537692b1ced390"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-armv7l-linux-gnueabihf.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "f351c0db74c098e6833f3f57aa0e8792eef8f73635902618291350321df16afa"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-armv7l-linux-gnueabihf.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "10b8c4332003c96aa0e55b0ff6894862d059d15a"
+git-tree-sha1 = "023f66ad795e940becb6138192644099f8671368"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-armv7l-linux-gnueabihf.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "78e284ef9d7933235169153e686bac6d091c926d3711c06228985623cfacd5c3"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-armv7l-linux-gnueabihf.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "c2759d548d070d3bd5e5006905d85aa62849ba634f89ad00e213507397f19fcc"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-armv7l-linux-musleabihf.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "21ba086fd9380b10a451bd846208b9228c957d30"
+git-tree-sha1 = "917d476f3315fc49198424c4035182d974f66ee7"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-armv7l-linux-musleabihf.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "b4b0e9651b5fbfe82a48c5550ab89247387285a0d7cb7ee693fbc42d786a3a11"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-armv7l-linux-musleabihf.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "5085bd1f498e2a0526a05fa3af7c5536be1709db9986ae08238b07596d912b20"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-armv7l-linux-musleabihf.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "a2874e1ba72beba0717718abed7826ce1693230c"
+git-tree-sha1 = "4b9b489d949a015e187a7cea487b67037b9e1584"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-armv7l-linux-musleabihf.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "00102ac1db40b7a96df80bc1a263c4a236ab6d7ce45416809e44afd652f8ec65"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-armv7l-linux-musleabihf.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "493f5615e52aa5c417064d90adab8311706450ea6568757e43b5a8dd2f163ad0"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-i686-linux-gnu.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "ffecb7cbfc6b2256f3f83b8ce64c37a56b0e8662"
+git-tree-sha1 = "becc59b46459da2374e3aeb2fbbaf3a43bc84f6e"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-i686-linux-gnu.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "dd02918ad4437bd7b6cd0202560ab577acefcbd5a867823d0aef9b4f1d4196aa"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-i686-linux-gnu.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "e34a6c7837e65484fe686e4718343ea6bafec48af5e8fd88d90d7c9c962a7332"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-i686-linux-gnu.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "2b9e4854d67fd814601d4c77df1fb16dd8276067"
+git-tree-sha1 = "8f0fea4f3872d8b07a6c50a832411e12f7f6279f"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-i686-linux-gnu.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "cbf590a3c849026f115ed906278d0ba5f77d35b463949c6b7c325102147d6f22"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-i686-linux-gnu.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "56b3f0bae3fcfdd5b9903d22c5f478cd4f252d2b03e8fc67a610856e3e072746"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-i686-linux-musl.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "153d4c9c0adc8ad205fd2858152e1e94d12d8979"
+git-tree-sha1 = "26e7c797182f6583b2d015b36499b89c8ea10ab7"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-i686-linux-musl.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "ab4cf6ad051837a721ccac2d7d5b0d6e0f3f8066020578abfa9ffeedc03ef547"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-i686-linux-musl.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "01fc4f0fff3185dfc7ff813e8d7d8782e16cea01aeeb491a5f8abb7130a5788e"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-i686-linux-musl.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "207c53b10f644520f8f61a63bde19a6d549e6acc"
+git-tree-sha1 = "57eeeccc7030cf901d882e1eafffed57b5db3170"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-i686-linux-musl.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "9f7f276e5313c7ba122716f74458dad31373ed9bf4f583a8aec64b0de37ba838"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-i686-linux-musl.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "cca35b096adc9e22b1ea39922165db94039fa2d064fe9ab0252af9481f37d296"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-i686-w64-mingw32.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "b64765749048a574549766e30a4589211ea1a203"
+git-tree-sha1 = "0017c72b4278ffc09a567f13efd22e1d9d4898e8"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-i686-w64-mingw32.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "22ca3ae5b8c283be91e757f2a461afdf82bf2553c52cc9f3632f899b089b8d9a"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-i686-w64-mingw32.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "26c47bd5651a2bc6eca94dfbeca1f6fb226ebaf427ea8d2a6cbf58777bd3969d"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-i686-w64-mingw32.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "0c7681a02e8a33a31cb56567366e74f7528d5ef4"
+git-tree-sha1 = "846fa13405e3785b34b44ce1b70e183406e3f0f6"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-i686-w64-mingw32.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "c4ce0cb18baea25cc9426ded27716b13d0e08678bfd3ec3478de80d8a42c8dfb"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-i686-w64-mingw32.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "a23e1f638397434552be742082ae3f75b95d616d4a5679c6ff5be7b1d381d8b8"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-powerpc64le-linux-gnu.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "faba93f86dc4df5a7a83005cea050020d39952ab"
+git-tree-sha1 = "52a662a89fc8a94eb2ae8e85e9f7b94e959e70e1"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-powerpc64le-linux-gnu.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "7cf6f37880076ca85f3ca0d762afcd58a79d500e49bb38c6212dc27ebbcf3445"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-powerpc64le-linux-gnu.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "a0563b90c2133f09a78aac561e7bf2551c8517fcb8d5969f519f90add8088839"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-powerpc64le-linux-gnu.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "411a05427f88fe16327503a04fcc36c9c39923cb"
+git-tree-sha1 = "a6c41c650d95c81fd116c15d86b22408a59702bc"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-powerpc64le-linux-gnu.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "87665b314cbc31610c64a747365e028d497b2962fd381262867b7f725ccefe1b"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-powerpc64le-linux-gnu.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "eeac1c672ccab57e827d71bdb851f4a75cbfc8b0742c27b02f54a0cde6004463"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-apple-darwin.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "0887eeb9210ba7d3afd6f17d215b76907d04af68"
+git-tree-sha1 = "4ed3e360244bab5c293fc5300c8c7ed4459f5522"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-apple-darwin.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "e8da0e5eb6c58ff73b52951ef71fb85e7521d9db0718254a5aec274dc21e292a"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-x86_64-apple-darwin.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "a33672ef7f1d45b162daa742428ca2f24f9730d63ce33f979a17121a94612d82"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-x86_64-apple-darwin.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "2c91c7eb39fceff834b9f77ff38b60786ee991af"
+git-tree-sha1 = "15736e29aeb9d7c8973f49061b52b56bc718c017"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-apple-darwin.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "95a0f5d19ec957d1156a329a45662722447526c19656a1782a86354b0c87d280"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-x86_64-apple-darwin.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "57539536a01b5a95d8c092bfa3087dc7cdffcfbce3e291b4c387227bd134c0e5"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-linux-gnu.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "be55b38615cd72f6b14bfd2d71068be268972e26"
+git-tree-sha1 = "c3a50fda3bb1067df6ac25068057f4b5971dbdae"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-linux-gnu.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "b0add988aea256f2d7f0c011a292c0417b1924a3cbfde865741b72dc1bf19db8"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-x86_64-linux-gnu.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "822dbdbfb4d4acc592e62aea3d56eaecf8d0a4eab9478690ad22469016b2ebc3"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-x86_64-linux-gnu.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "87b47c725c177095d03006319a8da34c4699b76c"
+git-tree-sha1 = "f132381d2f8f7bd9d70143b03d2317eba70f0820"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-linux-gnu.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "b0eb8dcae67580fe0b3527aa34573a8619d94e29ba45b4ac0b179e340ce575db"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-x86_64-linux-gnu.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "3693828b8f3fccbecaf213c4d8717a95a7329f1ce3ed644c4be5f0a472e77dc4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-linux-musl.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "dcbb2872ebb2155d53816980b6942fc49d873e74"
+git-tree-sha1 = "5e867eaf4198438e6e2b964a92a359a28438823f"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-linux-musl.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "3d645bb0e8eb2b6325b58d0fd5578082d9395d694b40f0d02b2697f56e2f88c1"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-x86_64-linux-musl.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "f70d83ed5b9726302324166ee905c5dd27d1b3b9d2de3161bc9237e05af60596"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-x86_64-linux-musl.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "56a453764625594387484bb796fb959797bd87cc"
+git-tree-sha1 = "a833b9311c9d06cbacddc8ea769d8a2840041bdd"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-linux-musl.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "5714c3b66bba76a123bf9439037ae55779ce9a0affe67cf194b1c9c6ff6a9a97"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-x86_64-linux-musl.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "fe5a583c78964ee49108a80e9d1f234540a92ddf3d8f1e540f32a6f5ebfd50a6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-unknown-freebsd.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "7bc3f283c6517eff8d8b52952c933b96b07fe33f"
+git-tree-sha1 = "23e04df431284abd87005e5550860a91f695e436"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-unknown-freebsd.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "9ee03c8a2b012c5b29778b4b600b88903f293edc7896c9ba58b0ba22aecdbde1"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-x86_64-unknown-freebsd.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "618b3e401738e087933c7f3a586b1a1727767d908d281104413c0f73f5288ead"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-x86_64-unknown-freebsd.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "f821a5c85930f7fed05bbcc1f242188afa1e9581"
+git-tree-sha1 = "da5437f319d2302759b3cf575b6988857ed3b042"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-unknown-freebsd.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "4b12565c4e34bdf54c66e683f86675314c2986082902d90f4baafeb95ab743d6"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-x86_64-unknown-freebsd.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "8aacd26cf5e54418403779a1d4a7a9a19797ed90c3fe034015fc4443108fbb61"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-w64-mingw32.v1.48.0.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "34e9fc94c794bdb0c17d9ae9f6643aab75b6076c"
+git-tree-sha1 = "4f995d8f9a0d1f1631f93e138ed0009ded0a8c81"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-w64-mingw32.v1.48.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "e14866f590b9c7214d758e6693c2cd57d2a3cb97a89305e9967d3979d94002f8"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-x86_64-w64-mingw32.v1.48.0.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "1f3d002a69d7d6f993accb061c74b190fa4bb67e5da066ca1bc171dd42ca8ae7"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-x86_64-w64-mingw32.v1.48.0.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "23f7235440f5e3db1e700e625982e1096d687d31"
+git-tree-sha1 = "7d86454dbb01713aa4ba403dbd9ea4c025608f28"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-w64-mingw32.v1.48.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "93c40f10053053952e1225d0a2aeb8cf1d073331ffbc71d04c99f1dce2164da5"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.48.0/RustToolchain-x86_64-w64-mingw32.v1.48.0.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "9302af586d24b8c60fe5268c2646c6ad4ac488458244219b8c5d7d3076701b89"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -484,7 +484,7 @@ function choose_shards(p::AbstractPlatform;
             ps_build::VersionNumber=v"2020.11.06",
             GCC_builds::Vector{GCCBuild}=available_gcc_builds,
             LLVM_builds::Vector{LLVMBuild}=available_llvm_builds,
-            Rust_build::VersionNumber=v"1.48.0",
+            Rust_build::VersionNumber=v"1.43.0",
             Go_build::VersionNumber=v"1.13",
             archive_type::Symbol = (use_squashfs ? :squashfs : :unpacked),
             bootstrap_list::Vector{Symbol} = bootstrap_list,

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -886,7 +886,7 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
         "CARGO_HOME" => "/opt/$(host_target)",
         "RUSTUP_HOME" => "/opt/$(host_target)",
         # TODO: we'll need a way to parameterize this toolchain number
-        "RUSTUP_TOOLCHAIN" => "1.48.0-$(map_rust_target(host_platform))",
+        "RUSTUP_TOOLCHAIN" => "1.43.0-$(map_rust_target(host_platform))",
 
         # We conditionally add on some compiler flags; we'll cull empty ones at the end
         "USE_CCACHE" => "$(use_ccache)",


### PR DESCRIPTION
This is required because of a regression in the `Rust` build on
i686-w64-mingw32: https://github.com/rust-lang/rust/issues/79609