### PR TITLE
Properly (de)serialize VersionSpec to JSON

### DIFF
--- a/src/Dependencies.jl
+++ b/src/Dependencies.jl
@@ -113,7 +113,7 @@ end
 # Add JSON serialization of dependencies
 string_or_nothing(x) = isnothing(x) ? x : string(x)
 
-# helper to get the version of a dependency (and no the build_version)
+# helper to get the version of a dependency (and not the build_version)
 version(d::AbstractDependency) = getpkg(d).version
 version(d::Dependency) = d.pkg.version
 

--- a/src/Dependencies.jl
+++ b/src/Dependencies.jl
@@ -113,43 +113,37 @@ end
 # Add JSON serialization of dependencies
 string_or_nothing(x) = isnothing(x) ? x : string(x)
 
-major(v::VersionNumber) = v.major
-minor(v::VersionNumber) = v.minor
-patch(v::VersionNumber) = v.patch
-major(v::Pkg.Types.VersionBound) = v.t[1]
-minor(v::Pkg.Types.VersionBound) = v.t[2]
-patch(v::Pkg.Types.VersionBound) = v.t[3]
-__version(v::VersionNumber) = v
-__version(v::Pkg.Types.VersionSpec) = v.ranges[1].lower
-version(d::AbstractDependency) = __version(getpkg(d).version)
-version(d::Dependency) = __version(d.pkg.version)
+# helper to get the version of a dependency (and no the build_version)
+version(d::AbstractDependency) = getpkg(d).version
+version(d::Dependency) = d.pkg.version
 
 for (type, type_descr) in ((Dependency, "dependency"), (BuildDependency, "builddependency"))
     JSON.lower(d::type) = Dict("type" => type_descr,
                                "name" => d.pkg.name,
                                "uuid" => string_or_nothing(d.pkg.uuid),
-                               "version-major" => major(version(d)),
-                               "version-minor" => minor(version(d)),
-                               "version-patch" => patch(version(d)))
+                               "version" => JSON.parse(JSON.json(version(d))))
 end
+
+import Pkg.Types: VersionBound, VersionRange, VersionSpec
+dejson(::Type{VersionBound}, d::Dict{String,Any}) = VersionBound(NTuple{d["n"],Int}(d["t"]))
+dejson(::Type{VersionRange}, d::Dict{String,Any}) = VersionRange(dejson(VersionBound, d["lower"]), dejson(VersionBound, d["upper"]))
+dejson(::Type{VersionSpec}, d::Dict{String,Any}) = VersionSpec([dejson(VersionRange, v) for v in d["ranges"]])
 
 # When deserialiasing the JSON file, the dependencies are in the form of
 # dictionaries.  This function converts the dictionary back to the appropriate
 # AbstractDependency.
 function dependencify(d::Dict)
-    if d["type"] == "dependency"
+    if haskey(d, "uuid") && haskey(d, "version") && haskey(d, "name")
         uuid = isnothing(d["uuid"]) ? d["uuid"] : UUID(d["uuid"])
-        version = VersionNumber(d["version-major"], d["version-minor"], d["version-patch"])
-        version = version == v"0" ? nothing : version
-        return Dependency(PackageSpec(; name = d["name"], uuid = uuid, version = version))
-    elseif d["type"] == "builddependency"
-        uuid = isnothing(d["uuid"]) ? d["uuid"] : UUID(d["uuid"])
-        version = VersionNumber(d["version-major"], d["version-minor"], d["version-patch"])
-        version = version == v"0" ? nothing : version
-        return BuildDependency(PackageSpec(; name = d["name"], uuid = uuid, version = version))
-    else
-        error("Cannot convert to dependency")
+        version = dejson(VersionSpec, d["version"])
+        pkg = PackageSpec(; name = d["name"], uuid = uuid, version = version)
+        if d["type"] == "dependency"
+            return Dependency(pkg)
+        elseif d["type"] == "builddependency"
+            return BuildDependency(pkg)
+        end
     end
+    error("Cannot convert to dependency")
 end
 
 

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -1,5 +1,7 @@
 using Test
-using Pkg, Base.BinaryPlatforms
+using Base.BinaryPlatforms
+using Pkg
+using Pkg.Types: VersionSpec
 using BinaryBuilderBase
 using BinaryBuilderBase: getname, getpkg, dependencify
 using JSON
@@ -17,11 +19,19 @@ end
 
 @testset "Dependencies" begin
     name = "Foo_jll"
+
     dep = Dependency(PackageSpec(; name = name))
     @test Dependency(name) == dep
     @test getname(dep) == name
-    @test getname(PackageSpec(; name = name)) == name
     @test getpkg(dep) == PackageSpec(; name = name)
+
+    dep_version = Dependency(PackageSpec(; name = name, version = v"1"))
+    @test getname(dep_version) == name
+    @test getpkg(dep_version) == PackageSpec(; name = name, version = v"1")
+
+    dep_vspec = Dependency(PackageSpec(; name = name, version = VersionSpec("1.1-1.4.5")))
+    @test getname(dep_vspec) == name
+    @test getpkg(dep_vspec) == PackageSpec(; name = name, version = VersionSpec("1.1-1.4.5"))
 
     build_version = v"1.2.3"
     dep_buildver = Dependency(PackageSpec(; name = name), build_version)
@@ -33,26 +43,89 @@ end
     build_dep = BuildDependency(PackageSpec(; name = build_name))
     @test BuildDependency(build_name) == build_dep
     @test getname(build_dep) == build_name
-    @test getname(PackageSpec(; name = build_name)) == build_name
     @test getpkg(build_dep) == PackageSpec(; name = build_name)
 
     @testset "JSON (de)serialization" begin
         jdep = JSON.lower(dep)
-        @test jdep == Dict("type" => "dependency", "name" => name, "uuid" => nothing, "version-major" => 0x0, "version-minor" => 0x0, "version-patch" => 0x0)
+        @test jdep == Dict(
+          "type" => "dependency",
+          "name" => name,
+          "uuid" => nothing,
+          "version" => Dict(
+            "ranges" => [
+              Dict(
+                "lower" => Dict("t" => [0,0,0], "n" => 0),
+                "upper" => Dict("t" => [0,0,0], "n" => 0)
+              )
+            ]
+          )
+        )
         @test dependencify(jdep) == dep
 
+        jdep_vspec = JSON.lower(dep_vspec)
+        @test jdep_vspec == Dict(
+          "type" => "dependency",
+          "name" => name,
+          "uuid" => nothing,
+          "version" => Dict(
+            "ranges" => [
+              Dict(
+                "lower" => Dict("t" => [1,1,0], "n" => 2),
+                "upper" => Dict("t" => [1,4,5], "n" => 3)
+              )
+            ]
+          )
+        )
+        @test dependencify(jdep_vspec) == dep_vspec
+
         jdep_buildver = JSON.lower(dep_buildver)
-        @test jdep_buildver == Dict("type" => "dependency", "name" => name, "uuid" => nothing, "version-major" => 0x0, "version-minor" => 0x0, "version-patch" => 0x0)
+        @test jdep_buildver == Dict(
+          "type" => "dependency",
+          "name" => name,
+          "uuid" => nothing,
+          "version" => Dict(
+            "ranges" => [
+              Dict(
+                "lower" => Dict("t" => [0,0,0], "n" => 0),
+                "upper" => Dict("t" => [0,0,0], "n" => 0)
+              )
+            ]
+          )
+        )
         # the build_version is currently not serialized, so the following test fails
         @test_broken dependencify(jdep_buildver) == dep_buildver
 
         jbuild_dep = JSON.lower(build_dep)
-        @test jbuild_dep == Dict("type" => "builddependency", "name" => build_name, "uuid" => nothing, "version-major" => 0x0, "version-minor" => 0x0, "version-patch" => 0x0)
+        @test jbuild_dep == Dict(
+          "type" => "builddependency",
+          "name" => build_name,
+          "uuid" => nothing,
+          "version" => Dict(
+            "ranges" => [
+              Dict(
+                "lower" => Dict("t" => [0,0,0], "n" => 0),
+                "upper" => Dict("t" => [0,0,0], "n" => 0)
+              )
+            ]
+          )
+        )
         @test dependencify(jbuild_dep) == build_dep
 
         full_dep = Dependency(PackageSpec(; name = "Baz_jll", uuid = "00000000-1111-2222-3333-444444444444", version = "3.1.4"))
         jfull_dep = JSON.lower(full_dep)
-        @test jfull_dep == Dict("type" => "dependency", "name" => "Baz_jll", "uuid" => "00000000-1111-2222-3333-444444444444", "version-major" => 0x3, "version-minor" => 0x1, "version-patch" => 0x4)
+        @test jfull_dep == Dict(
+          "type" => "dependency",
+          "name" => "Baz_jll",
+          "uuid" => "00000000-1111-2222-3333-444444444444",
+          "version" => Dict(
+            "ranges" => [
+              Dict(
+                "lower" => Dict("t" => [3,1,4], "n" => 3),
+                "upper" => Dict("t" => [3,1,4], "n" => 3)
+              )
+            ]
+          )
+        )
         @test dependencify(jfull_dep) == full_dep
         @test_throws ErrorException dependencify(Dict("type" => "git"))
     end


### PR DESCRIPTION
This changes `Dependency` objects to always (?) store a full `VersionSpec`, not just a `VersionNumber`, and (de)serialize that properly.  Fixes #89 (well, I hope).

Before this, https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/981 should be merged.

CC @benlorenz @thofma