### PR TITLE
Fix MacOS GCC shards

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1246,157 +1246,157 @@ os = "linux"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "53da269bc01161c77b0aa6cdd9ee338d442bcac5"
+git-tree-sha1 = "bea32c300b87f79585268bccfc27bc7559e2f58f"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "b824e6d64badea3667329a319f6430703e2c1bfa5d2999642f1e9f3b17f44f9f"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0/GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "a52bc662da73dcdf422d1768e0c985320a65c8e7348d4de99f43d1791775573a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+0/GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "c23dbfacefb2fb3d2fabfae5fa2b49ed39c216df"
+git-tree-sha1 = "c7130ed1e7ce7f2330842114bad067a476427cc3"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "d85e8cecdbd1005c53df32a2ff513fe4c908218be948edab4596748cdfe10b41"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0/GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "3b3ca560e23fe22271fea2bbd357d3c9cd83821d6688cc59217aacb1fb9d59c5"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+0/GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "494917abac03f3254f02e9915f9c85e252ffc555"
+git-tree-sha1 = "f7915abce1746466c4638ac778eb63c87c9b4e87"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.squashfs".download]]
-    sha256 = "278285d0f2231fac9c8a9beceeb8bb5b2ec4b032a422c3bb27012a7e391b6558"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+5/GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "2858f85eb64f289d93ebcacf992297623c85748b501bdbe8038b6fa1100728d7"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+6/GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "93a7a8d48d93c3ed2434bc5089aa08421e698fa8"
+git-tree-sha1 = "678e51f4b65e4d344faaa59ce05286f4f61b18e7"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.unpacked".download]]
-    sha256 = "b010618c11000439463ee7fdfa0baf5c2a5561ab271d77c9defad2ad68b9612b"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+5/GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "1f59dc2e245d94d13048b4968c17f832d282fe95986291157407b58bee22b4a4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+6/GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "b3c87acf90c309ae4f6a8f84a62e88d89d373043"
+git-tree-sha1 = "8db4790c25c4b9ff23725e23d1265500a403dead"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "9cd503eef98863f5ef0be1a6f00fe7e0b746e58f381304e31a5b89eab3fa5fc7"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+3/GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "eaf53c090b336377804a126f4be7eed12df6fd11c080f106d2a78f0f4c119e0f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+4/GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "7f85def408ba3b30aad4e087df04281c75062248"
+git-tree-sha1 = "522feb508d32f12cca1180cf6df09309b1fc910d"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "f19f29f3fb0e6f08dd6130ab67f1b0183e50b25775b5d9d6f526a698506acd42"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+3/GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "fb2eb159e85828758f4204c4f1653e3d67545d9bed19ca96370200fad3abd327"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+4/GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "36731a4227b561e400b0c3bd14d71e964d6b080c"
+git-tree-sha1 = "c595c01b3a935f5e94de54324ef78cc200c5dca4"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "670a88ad7d63e6b0b54e712f78692955df2a5568b3e127e7106a2f890f33697a"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+3/GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "f82528aa0e465a55a67947f401f89a54551ed97422eacf01a4e4e6d10326161e"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "5c10897b6c9ba5c938aeba86386ba7f71587bb88"
+git-tree-sha1 = "9ffeb139defce72dc3311f48441a37393b455c36"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "4f3354c4b72cf8f1b2b40a585ca0abba09a342a38505113e1c264aab306233ae"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+3/GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "02aacf1284f8f26ea94ca9dce610a5f1945df4dc2f091f52b6d5c9a087ae277c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "091b2e101c2ab39e8e64f0222bc9665cf7bad672"
+git-tree-sha1 = "edc1c72616c19f01403ba811a42ec78aa5a84485"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "b2ee74461e7863a6dc9f8e9c64124c57fc8034eb1543ede8707b666a82afd45f"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+3/GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "03d31b11924223be6346a0472b42b32c05a6289958d6d892e50c165c90548574"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "7c423788d5fdd8ec94bb28d92a597a9b5701dbe4"
+git-tree-sha1 = "0ad4499ebb8c7c02db00dec492971836e2e0e5d2"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "48fa94a0fe6630cbfc066401e9234a06d4cece5e8651ca11d049d77d45ab0702"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+3/GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "70a5412c23d088838608ab8d7f39a6e4c5870123ec22507dd27b470287dd72f6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "565f9bfc00088b8d06308dd3afc2a54ca62ebbac"
+git-tree-sha1 = "498361f8826b4dc7c65281af2dbf2fbd134193f3"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "3af62971bbad39d9717978697923c4002236d448f4137ca1ab3feb8ddea4302c"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+3/GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "601647964228c9df17cb6012aae4ccdfe1f59d9dacbeac9219ab01f717729449"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "da5f8f244b11940ff86a644c2989ed43d8ff89af"
+git-tree-sha1 = "7f8518c7a9f40a9eb0d43a35e2fbbce88e05d785"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "24a4dc9d8d970a6c5d341462c57f718d1778c42d218f2ebb559af1fe7db84f6a"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+3/GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "6e5a592f0e3acfd0f74d7fc55cfd3250cee9041d27ceaa6759b1fb373320d566"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "c8ed5d22e83e37006f64155e4f5a869b85ea8944"
+git-tree-sha1 = "53ffd834e425216ed1f23a9a6002d119318bb367"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "dfdedaeb1ae6f58a91eb3bd4e0c838c48762d48d4bf5d33c55c51c271c6a77f1"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+2/GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "50dbce1074dc64b395e24546f1d82cddf184b1465938c142929473cb5d800ec6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+3/GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "0729749be50e3642a5c360172f74e52d573f2009"
+git-tree-sha1 = "becb09d6c7810ed490746c7e4c5a6968cd897c09"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "6a3ce8664b1164020c8c44137563388659e951ec503c8935104478acc6e584da"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+2/GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "bebee6ef684d0b708d5a8efa2fded213d7f1e48f2d9e677ce2ac09de402fd0f5"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+3/GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-gnu.v10.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -560,7 +560,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             return (io, p) -> nothing
         end
 
-        return wrapper(io, "/opt/$(aatriplet(p))/bin/llvm-dsymutil"; allow_ccache=false)
+        return wrapper(io, "/opt/$(aatriplet(p))/bin/dsymutil"; allow_ccache=false)
     end
 
     function readelf(io::IO, p::AbstractPlatform)
@@ -948,7 +948,7 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
         for (env_name, tool) in (
             "CC" => "$(host_bin_dir)/$(host_target)-gcc",
             "CXX" => "$(host_bin_dir)/$(host_target)-g++",
-            "DSYMUTIL" => "llvm-dsymutil",
+            "DSYMUTIL" => "dsymutil",
             "FC" => "$(host_bin_dir)/$(host_target)-gfortran"
            )
             mapping[host_map(env_name)] = tool


### PR DESCRIPTION
Our MacOS shards are now providing `dsymutil` as the primary name, so
just use that instead.