### PR TITLE
Refactor pigz support

### DIFF
--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -173,7 +173,7 @@ function package(prefix::Prefix,
         @info("Tree hash of contents of $(basename(out_path)): $(tree_hash)")
     end
 
-    tarball_hash = _archive_artifact(tree_hash, out_path; honor_overrides=false)
+    tarball_hash = archive_artifact(tree_hash, out_path; honor_overrides=false)
     if verbose
         @info("SHA256 of $(basename(out_path)): $(tarball_hash)")
     end

--- a/test/archive_utils.jl
+++ b/test/archive_utils.jl
@@ -1,0 +1,64 @@
+using BinaryBuilderBase: archive_artifact, package
+using Pkg.Artifacts: create_artifact, remove_artifact, with_artifacts_directory
+using Pkg: PlatformEngines
+
+@testset "Archive Utils" begin
+    @testset "package" begin
+        mktempdir() do prefix
+            # Create random files
+            mkpath(joinpath(prefix, "bin"))
+            mkpath(joinpath(prefix, "lib"))
+            mkpath(joinpath(prefix, "etc"))
+            bar_path = joinpath(prefix, "bin", "bar.sh")
+            open(bar_path, "w") do f
+                write(f, "#!/bin/sh\n")
+                write(f, "echo yolo\n")
+            end
+            baz_path = joinpath(prefix, "lib", "baz.so")
+            open(baz_path, "w") do f
+                write(f, "this is not an actual .so\n")
+            end
+
+            qux_path = joinpath(prefix, "etc", "qux.conf")
+            open(qux_path, "w") do f
+                write(f, "use_julia=true\n")
+            end
+
+            mktempdir() do output_dir
+                for (format, ext) in [("gzip", "gz"), ("xz", "xz")]
+                    tarball_path =  joinpath(output_dir, "foo.tar.$ext")
+                    package(prefix, tarball_path; format=format)
+                    @test isfile(tarball_path)
+
+                    # Test that we can inspect the contents of the tarball
+                    contents = PlatformEngines.list_tarball_files(tarball_path)
+                    @test "bin/bar.sh" in contents
+                    @test "lib/baz.so" in contents
+                    @test "etc/qux.conf" in contents
+                end
+            end
+        end
+    end
+
+    @testset "Artifact archival" begin
+        mktempdir() do art_dir
+            with_artifacts_directory(art_dir) do
+                hash = create_artifact(p -> touch(joinpath(p, "foo")))
+                tarball_path = joinpath(art_dir, "foo.tar.gz")
+                archive_artifact(hash, tarball_path)
+                @test "foo" in PlatformEngines.list_tarball_files(tarball_path)
+                rm(tarball_path)
+
+                # Test custom `package` function and ensure failure if no `tarball_path` file
+                # is created.
+                package_alt(src_dir, tarball_path) = nothing
+                @test !isfile(tarball_path)
+                @test_throws SystemError archive_artifact(hash, tarball_path, package=package_alt)
+
+                # Test archiving something that doesn't exist fails
+                remove_artifact(hash)
+                @test_throws ErrorException archive_artifact(hash, tarball_path)
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 # Run all our tests
 include("compat.jl")
+include("archive_utils.jl")
 include("dependencies.jl")
 include("platforms.jl")
 include("prefix.jl")


### PR DESCRIPTION
While building a new GCCBootstrap I noticed that `7z` was being used for compressing the "unpacked" artifact. As the original point of [using `pigz`](https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/107) was to improve the compression time when building shards I tracked this down and found this [call to `archive_artifact` in Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil/blob/2fba739eec6d70724d6594a4e5c011fc872cc8e8/0_RootFS/common.jl#L48). In order to fix this I could revise Yggdrasil to use `_archive_artifact` but since this custom version of `archive_artifact` will be used beyond just BinaryBuilderBase I thought it best to clean up the interface first.

Additionally, I used this PR to add support for compressing artifacts in the `xz` format as discussed in https://github.com/JuliaLang/Pkg.jl/pull/2375#issuecomment-771828722. Currently, support for this is opt-in and would be done via:

```julia
archive_artifact(...; package=(src_dir, tarball_path) -> package(src_dir, tarball_path, format="xz"))
```
We could add a convenience function `package(format::AbstractString) = (src_dir, tarball_path) -> package(src_dir, tarball_path, format=format)` but I decided to leave that out for now.

