### PR TITLE
Mount existing `/etc/resolv.conf` in `UserNSRunner` if it has nameserver settings

### DIFF
--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -67,14 +67,14 @@ function UserNSRunner(workspace_root::String;
     # specified and if yes, mount the existing `/etc/resolv.conf` to make use
     # of system-specific nameserver settings
     if (Sys.isbsd() || Sys.islinux()) && isfile("/etc/resolv.conf")
-      if any(startswith(line, "nameserver") for line in eachline("/etc/resolv.conf"))
-        # We copy the contents of `/etc/resolv.conf` to a temporary file and mount that one,
-        # such that `/etc/resolv.conf` is editable inside the container
-        tmppath, tmpio = mktemp()
-        write(tmpio, read("/etc/resolv.conf", String))
-        flush(tmpio) # required as otherwise `tmppath` remains empty
-        push!(workspaces, tmppath => "/etc/resolv.conf")
-      end
+        if any(startswith(line, "nameserver") for line in eachline("/etc/resolv.conf"))
+            # We copy the contents of `/etc/resolv.conf` to a temporary file and mount that one,
+            # such that `/etc/resolv.conf` is editable inside the container
+            tmppath, tmpio = mktemp()
+            write(tmpio, read("/etc/resolv.conf", String))
+            flush(tmpio) # required as otherwise `tmppath` remains empty
+            push!(workspaces, tmppath => "/etc/resolv.conf")
+        end
     end
 
     if isnothing(shards)

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -67,12 +67,9 @@ function UserNSRunner(workspace_root::String;
     # specified and if yes, mount the existing `/etc/resolv.conf` to make use
     # of system-specific nameserver settings
     if (Sys.isbsd() || Sys.islinux()) && isfile("/etc/resolv.conf")
-        for line in eachline("/etc/resolv.conf")
-            if startswith(line, "nameserver")
-              push!(workspaces, "/etc/resolv.conf" => "/etc/resolv.conf")
-              break
-            end
-        end
+      if any(startswith(line, "nameserver") for line in eachline("/etc/resolv.conf"))
+        push!(workspaces, "/etc/resolv.conf" => "/etc/resolv.conf")
+      end
     end
 
     if isnothing(shards)

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -62,6 +62,19 @@ function UserNSRunner(workspace_root::String;
         push!(workspaces, ccache_dir() => "/root/.ccache")
     end
 
+    # If we are on a system that uses `/etc/resolv.conf` as a resolver
+    # configuration file (mainly *BSD and Linux), check if a nameserver is
+    # specified and if yes, mount the existing `/etc/resolv.conf` to make use
+    # of system-specific nameserver settings
+    if (Sys.isbsd() || Sys.islinux()) && isfile("/etc/resolv.conf")
+        for line in eachline("/etc/resolv.conf")
+            if startswith(line, "nameserver")
+              push!(workspaces, "/etc/resolv.conf" => "/etc/resolv.conf")
+              break
+            end
+        end
+    end
+
     if isnothing(shards)
         # Choose the shards we're going to mount
         shards = choose_shards(platform; extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:bootstrap_list,:compilers))...)

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -68,7 +68,12 @@ function UserNSRunner(workspace_root::String;
     # of system-specific nameserver settings
     if (Sys.isbsd() || Sys.islinux()) && isfile("/etc/resolv.conf")
       if any(startswith(line, "nameserver") for line in eachline("/etc/resolv.conf"))
-        push!(workspaces, "/etc/resolv.conf" => "/etc/resolv.conf")
+        # We copy the contents of `/etc/resolv.conf` to a temporary file and mount that one,
+        # such that `/etc/resolv.conf` is editable inside the container
+        tmppath, tmpio = mktemp()
+        write(tmpio, read("/etc/resolv.conf", String))
+        flush(tmpio) # required as otherwise `tmppath` remains empty
+        push!(workspaces, tmppath => "/etc/resolv.conf")
       end
     end
 


### PR DESCRIPTION
As discussed with @staticfloat and @giordano on Slack (https://julialang.slack.com/archives/C674ELDNX/p1613895520011000?thread_ts=1613741887.479600&cid=C674ELDNX).

The purpose is to avoid problems on systems where specific nameserver settings are applied in `/etc/resolv.conf`. In this case it makes sense to use the local `/etc/resolv.conf`, e.g., if the default DNS servers used by `BinaryBuilderBase` (Google's DNS servers) are not reachable from within the local network.

I have tested this locally on an Ubuntu machine and it fixed the issue I had with unreachable Google DNS servers, but I have not been able to test it on non-Ubuntu systems.

@staticfloat Is this implementation what you had in mind? One downside of the current approach is that `/etc/resolv.conf` is not editable anymore, precluding any way for the user to manually fix DNS issues (as I did before). Would it make sense to mount `/etc/resolv.conf` as a writable file? And if yes, how to go about it? I assume one would have to tell Docker (?) to not mount the file but really copy it.