### PR TITLE
[Runner] Set `SHELL` environment variable inside the runner

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -823,6 +823,9 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
         "HISTFILE"=>"/meta/.bash_history",
         "TERM" => "screen",
         "SRC_NAME" => src_name,
+        # The environment inherits the `SHELL` variable from the host, but some
+        # tools refer to this variable, make it consistent with our environment
+        "SHELL" => "/bin/bash",
     )
 
     # If we're bootstrapping, that's it, quit out.


### PR DESCRIPTION
The variable is inherit from the host, but some tools (like [GDB](https://sourceware.org/gdb/onlinedocs/gdb/Environment.html)) expect the
variable to be set to the actual shell used inside the build environment.