### PR TITLE
Fix `clock_gettime` errors on old macOS machines

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1254,157 +1254,157 @@ os = "linux"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "bea32c300b87f79585268bccfc27bc7559e2f58f"
+git-tree-sha1 = "26139b79927c0f2557c200bd01ce1adfaa816d46"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "a52bc662da73dcdf422d1768e0c985320a65c8e7348d4de99f43d1791775573a"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+0/GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "51a81cb1a2dbea1aa3875b6cef521204580a2f372daecd7140b07c84a59c85a9"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+1/GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "c7130ed1e7ce7f2330842114bad067a476427cc3"
+git-tree-sha1 = "0108431575f65015dabb33516464ad34e4cf993b"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "3b3ca560e23fe22271fea2bbd357d3c9cd83821d6688cc59217aacb1fb9d59c5"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+0/GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "6833d89663385af03d31f97cf26c34664ba7afbcf4c629ef7de891fddab09334"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+1/GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "f7915abce1746466c4638ac778eb63c87c9b4e87"
+git-tree-sha1 = "665a96279cda5d5cf23f13ce3970353b5c1f2ec8"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.squashfs".download]]
-    sha256 = "2858f85eb64f289d93ebcacf992297623c85748b501bdbe8038b6fa1100728d7"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+6/GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "a5d7d63f98c789aca3c5d313d2039bcef00c83515a2988b899f828fe48344c8b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+7/GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "678e51f4b65e4d344faaa59ce05286f4f61b18e7"
+git-tree-sha1 = "243126f2ab5d127398cd82a9ea290ed317990e4f"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.unpacked".download]]
-    sha256 = "1f59dc2e245d94d13048b4968c17f832d282fe95986291157407b58bee22b4a4"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+6/GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "022fa2e36eceff87ed5857c8a3ec7039bf38f55f394130702a901f96d525d285"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+7/GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "8db4790c25c4b9ff23725e23d1265500a403dead"
+git-tree-sha1 = "c6093f4ae602881b065d22a7c94f58e4a2015936"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "eaf53c090b336377804a126f4be7eed12df6fd11c080f106d2a78f0f4c119e0f"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+4/GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "b8eeaa34499ae14ac49075ac3e38b3bcf1067d06220a2e3d4fdd37486fb6f6cd"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+5/GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "522feb508d32f12cca1180cf6df09309b1fc910d"
+git-tree-sha1 = "1c42475fe174b81481b4d8d11239dbf85e469b42"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "fb2eb159e85828758f4204c4f1653e3d67545d9bed19ca96370200fad3abd327"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+4/GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "5776b16befe684ce2f3a6721bf5a00e3a0bc546ea2acdf3464d8cfcaf8b5d56c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+5/GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "c595c01b3a935f5e94de54324ef78cc200c5dca4"
+git-tree-sha1 = "7dc77333ecfafac3f50dd1313625eef60f62d253"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "f82528aa0e465a55a67947f401f89a54551ed97422eacf01a4e4e6d10326161e"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "9e3e7efb69c31cfff02c735e8f808373fcadf2961cd89bdba8d173e0c69af9f0"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "9ffeb139defce72dc3311f48441a37393b455c36"
+git-tree-sha1 = "47a7f1888388d4a9fdb81c78159ef8574ef9360d"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "02aacf1284f8f26ea94ca9dce610a5f1945df4dc2f091f52b6d5c9a087ae277c"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "c4d01f7bfaf7d9110e14fdc335968a0d50cd5c9511336403f31c9235a58860a4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "edc1c72616c19f01403ba811a42ec78aa5a84485"
+git-tree-sha1 = "df7ae73168e03c18551caa67d3dc657f9c63ef42"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "03d31b11924223be6346a0472b42b32c05a6289958d6d892e50c165c90548574"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "f9933766c45497682123bf9afb78c7a349897fb71e920531d3cbc7a74bbc81ad"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "0ad4499ebb8c7c02db00dec492971836e2e0e5d2"
+git-tree-sha1 = "1231eeb9af98fb4524f46a598cd2393c335e7770"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "70a5412c23d088838608ab8d7f39a6e4c5870123ec22507dd27b470287dd72f6"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "f534b25ea7ed546e09ea95a8f8ab666308351e9ab6445424fc29a31ab4891bfc"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "498361f8826b4dc7c65281af2dbf2fbd134193f3"
+git-tree-sha1 = "dcb3a04dad0a2c82079128c691343d0bfa6e63b3"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "601647964228c9df17cb6012aae4ccdfe1f59d9dacbeac9219ab01f717729449"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "c108e6d7a4f763da2603d7c8143296b7dde3f6440b8d88f5fd07360c5195f0d4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "7f8518c7a9f40a9eb0d43a35e2fbbce88e05d785"
+git-tree-sha1 = "aaa4fdfa7ee9b0562153e095b1bf42e1d42f770d"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "6e5a592f0e3acfd0f74d7fc55cfd3250cee9041d27ceaa6759b1fb373320d566"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "6fe75c3b1dd0ed409a57b9d9ddb40d2eaaa64ef0c7a005eef4717c19ac135093"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "53ffd834e425216ed1f23a9a6002d119318bb367"
+git-tree-sha1 = "dd9960b837f5c33863b6974c43789fb63c5b595f"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "50dbce1074dc64b395e24546f1d82cddf184b1465938c142929473cb5d800ec6"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+3/GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "9735ccb4b0dc65a70f43f8072f1323bbf4881d3f01425804b715286ccdd63b19"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "becb09d6c7810ed490746c7e4c5a6968cd897c09"
+git-tree-sha1 = "d30568b763191bfc499ad25c8985ee0f30893cc8"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "bebee6ef684d0b708d5a8efa2fded213d7f1e48f2d9e677ce2ac09de402fd0f5"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+3/GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "052c0e1c06baf9f97b3892947b878f744c7173cbd614ddbd19b7146336b43859"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-gnu.v10.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"


### PR DESCRIPTION
Our GCC shards did not correctly configure themselves to target the
oldest supported macOS build.  Instead, because GCC doesn't fully
understand how to use the availability macros that macOS uses, it
assumed that it was able to use `clock_gettime()`, which caused a
reliance on that symbol within `libgfortran` itself.  This resulted in
our CSL being unusable on macOS 10.11 and earlier.  This PR updates the
GCC shards [0] and also adds compiler flags to enforce that users who
attempt to use `gcc` on macOS do not end up making the same mistake.

[0] https://github.com/JuliaPackaging/Yggdrasil/pull/2836