### PR TITLE
Add host_libdir to the LD_LIBRARY_PATH

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -917,6 +917,7 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
             csl_paths(host_platform),
             # Add our target/host-specific library directories for compiler support libraries
             target_lib_dir(host_platform),
+            "$host_libdir",
             target_lib_dir(platform),
             # Finally, dependencies
             "$(prefix)/lib64:$(prefix)/lib",

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -915,9 +915,10 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
             "/lib64:/lib",
             # Add our CSL libraries for all architectures that can natively run within this environment
             csl_paths(host_platform),
+            # Libdir of the host platform, to run programs in `HostBuildDependency`
+            "$(host_libdir)",
             # Add our target/host-specific library directories for compiler support libraries
             target_lib_dir(host_platform),
-            "$host_libdir",
             target_lib_dir(platform),
             # Finally, dependencies
             "$(prefix)/lib64:$(prefix)/lib",


### PR DESCRIPTION
This may be needed to run tools included in a HostBuildDependency,
as in Qt6.

See also https://github.com/JuliaPackaging/Yggdrasil/pull/2856#discussion_r615287341