### PR TITLE
Update `GCCBoostrap` on macOS to avoid `mkostemp`

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1254,157 +1254,157 @@ os = "linux"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "26139b79927c0f2557c200bd01ce1adfaa816d46"
+git-tree-sha1 = "9f31aa37f585289cdbf3e8d6be9c3d1a7150b75a"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "51a81cb1a2dbea1aa3875b6cef521204580a2f372daecd7140b07c84a59c85a9"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+1/GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "1e195363e416dacfbb4992f30a698930962648ef562c775070e89acd5af74c5f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+2/GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "0108431575f65015dabb33516464ad34e4cf993b"
+git-tree-sha1 = "8f5bfb2d403cf1b91cc516791aa4b84ec5373ead"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "6833d89663385af03d31f97cf26c34664ba7afbcf4c629ef7de891fddab09334"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+1/GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "39bbdd70e8c58f4f7d70be69c0c24d2d255746ed798cdc32e64ef6a7dd953c52"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+2/GCCBootstrap-x86_64-apple-darwin14.v10.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "665a96279cda5d5cf23f13ce3970353b5c1f2ec8"
+git-tree-sha1 = "2a72bae39ca5a8378ee6036b4543c1e745b9b1c9"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.squashfs".download]]
-    sha256 = "a5d7d63f98c789aca3c5d313d2039bcef00c83515a2988b899f828fe48344c8b"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+7/GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "8a80d0a1f337a9d3a38cb635f4f479165cf35614efef3c9b424fa507ca44814c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+8/GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "243126f2ab5d127398cd82a9ea290ed317990e4f"
+git-tree-sha1 = "303e65f6896f295459c81aa311b5eb993f702d89"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.unpacked".download]]
-    sha256 = "022fa2e36eceff87ed5857c8a3ec7039bf38f55f394130702a901f96d525d285"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+7/GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "14b02d187c73f3b068362ed29856a993b7db376a8572393de144941c5e21a98a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+8/GCCBootstrap-x86_64-apple-darwin14.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "c6093f4ae602881b065d22a7c94f58e4a2015936"
+git-tree-sha1 = "d587821df47b32587badeb43715cb3b68f93a79a"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "b8eeaa34499ae14ac49075ac3e38b3bcf1067d06220a2e3d4fdd37486fb6f6cd"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+5/GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "8a3c4e9b7ecf0bc00f6e1fbef6a7f02d6935f57dd94c8d40458f2d77dbceadf6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+6/GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "1c42475fe174b81481b4d8d11239dbf85e469b42"
+git-tree-sha1 = "db3775fd1c017f4b005a4b17142aa7c9d273dd34"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "5776b16befe684ce2f3a6721bf5a00e3a0bc546ea2acdf3464d8cfcaf8b5d56c"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+5/GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "554170909e621b347748ace271c89e0f4828f68877306f6550fd54f91ea55585"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+6/GCCBootstrap-x86_64-apple-darwin14.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "7dc77333ecfafac3f50dd1313625eef60f62d253"
+git-tree-sha1 = "a7cbedbc13867451e1b70aebb4f5b9c2190a50b2"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "9e3e7efb69c31cfff02c735e8f808373fcadf2961cd89bdba8d173e0c69af9f0"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "141038050838fd31a7cdf5a305dd9df43bac0f7c18dc7b843ead33dff46e0481"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+6/GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "47a7f1888388d4a9fdb81c78159ef8574ef9360d"
+git-tree-sha1 = "01e2aee109bbfff72ccc2d8b4682aa982f0c6163"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "c4d01f7bfaf7d9110e14fdc335968a0d50cd5c9511336403f31c9235a58860a4"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "d92c642c88c4c678578d68eaf74f5d246f9eeca6b229f004bc41c84e537dd5ab"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+6/GCCBootstrap-x86_64-apple-darwin14.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "df7ae73168e03c18551caa67d3dc657f9c63ef42"
+git-tree-sha1 = "2a438b7380febd64df3996315535f4b714b9474b"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "f9933766c45497682123bf9afb78c7a349897fb71e920531d3cbc7a74bbc81ad"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "1c09c7a8ef499903c4d14910d6c57ac445bbbfca4ccbbabff5d32c2b9e75ed3c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+6/GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "1231eeb9af98fb4524f46a598cd2393c335e7770"
+git-tree-sha1 = "52713b95a1a99c3ca6b133de02e1ede556076f4f"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "f534b25ea7ed546e09ea95a8f8ab666308351e9ab6445424fc29a31ab4891bfc"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "38cf65a0eaa41078936f0552088613e04e02587cfcff5ccb026156d5a232e368"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+6/GCCBootstrap-x86_64-apple-darwin14.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "dcb3a04dad0a2c82079128c691343d0bfa6e63b3"
+git-tree-sha1 = "a7b318a85e338f9218a6bf7176dca5c5c2b0e0f4"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "c108e6d7a4f763da2603d7c8143296b7dde3f6440b8d88f5fd07360c5195f0d4"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "f077c49346bd77fe3fc64bcbdad78bf27de54ea00eafba2acba41406748133d0"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+6/GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "aaa4fdfa7ee9b0562153e095b1bf42e1d42f770d"
+git-tree-sha1 = "7c9af56fc40f893635f94720313af9ffb51d69ba"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "6fe75c3b1dd0ed409a57b9d9ddb40d2eaaa64ef0c7a005eef4717c19ac135093"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "078fe52aecbedd4204ff703c99d321c6e58ae8897084843b3636e87a156fb589"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+6/GCCBootstrap-x86_64-apple-darwin14.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "dd9960b837f5c33863b6974c43789fb63c5b595f"
+git-tree-sha1 = "4959443d85e8bca7990069d2b98d7a04c3d845ac"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "9735ccb4b0dc65a70f43f8072f1323bbf4881d3f01425804b715286ccdd63b19"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "cd91e01d2ca543bb3436d6f3c874920f35e4e09cac3227ea9d094f6886fd6c24"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "d30568b763191bfc499ad25c8985ee0f30893cc8"
+git-tree-sha1 = "9625f9be05b16b9cd7d77c96360ad8f417ebd140"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "052c0e1c06baf9f97b3892947b878f744c7173cbd614ddbd19b7146336b43859"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+4/GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "95b553ce0b513288b0813237146accc647640bde7d17b84093accf090d16015c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+5/GCCBootstrap-x86_64-apple-darwin14.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-linux-gnu.v10.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"


### PR DESCRIPTION
X-ref: https://github.com/JuliaPackaging/Yggdrasil/pull/2901