### PR TITLE
Reorganise Objective-C wrapper and Meson toolchain file

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -389,9 +389,8 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         )
     end
 
-    function clang_wrapper(io::IO, tool::String, p::AbstractPlatform, extra_flags::Vector{String} = String[])
+    function clang_wrapper(io::IO, tool::String, p::AbstractPlatform)
         flags = clang_flags!(p)
-        append!(flags, extra_flags)
         return wrapper(io,
             "/opt/$(host_target)/bin/$(tool)";
             flags=flags,
@@ -408,7 +407,6 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
 
     clang(io::IO, p::AbstractPlatform)    = clang_wrapper(io, "clang", p)
     clangxx(io::IO, p::AbstractPlatform)  = clang_wrapper(io, "clang++", p)
-    objc(io::IO, p::AbstractPlatform)     = clang_wrapper(io, "clang", p, ["-x objective-c"])
 
     # Our general `cc`  points to `gcc` for most systems, but `clang` for MacOS and FreeBSD
     function cc(io::IO, p::AbstractPlatform)
@@ -499,7 +497,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             "FC"     => "$(host_target)-f77",
             "LD"     => "$(host_target)-ld",
             "NM"     => "$(host_target)-nm",
-            "OBJC"   => "$(host_target)-objc",
+            "OBJC"   => "$(host_target)-cc",
             "RANLIB" => "$(host_target)-ranlib",
         )
         wrapper(io, "/usr/bin/meson"; allow_ccache=false, env=meson_env)
@@ -628,7 +626,6 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             write_wrapper(gxx, p, "$(t)-g++")
             write_wrapper(clang, p, "$(t)-clang")
             write_wrapper(clangxx, p, "$(t)-clang++")
-            write_wrapper(objc, p, "$(t)-objc")
 
             # Someday, you will be split out
             write_wrapper(gfortran, p, "$(t)-f77")
@@ -728,7 +725,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     end
 
     if :c in compilers
-        append!(default_tools, ("cc", "c++", "cpp", "f77", "gfortran", "gcc", "clang", "g++", "clang++", "objc"))
+        append!(default_tools, ("cc", "c++", "cpp", "f77", "gfortran", "gcc", "clang", "g++", "clang++"))
     end
     if :rust in compilers
         append!(default_tools, ("rustc","rustup","cargo"))
@@ -939,7 +936,6 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
         # Default mappings for some tools
         "CC" => "cc",
         "CXX" => "c++",
-        "OBJC" => "objc",
         "FC" => "gfortran",
         "GO" => "go",
         "RUSTC" => "rustc",


### PR DESCRIPTION
We can't make the Objective-C compiler always be the same as
`clang -x objective-c` because this won't work when using the compiler as linker: when
specifying the language with `-x <LANG>` the input files are assumed to always
be plain text source code files, but you pass object files to the linker.

This changeset removes the `objc` wrapper, which was created solely with the
goal to build Glib with Meson (which we never managed to do so far anyways) and
instead sets in the Meson toolchain file the Objective-C compiler to `cc` and
passes `-x objective-c` only when compiling but not linking.  This is more
correct and less error-prone than what we have now.

We also automatically add `-I${includedir}` and `-L{libdir}` for all languages
in the Meson toolchain file, to avoid having to manually patch this file during
builds, as Meson doesn't read environment variables when doing
cross-compilation.

---

In the previous episodes of the Objective-C compiler wrapper in BinaryBuilder:

* https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/426
* https://github.com/JuliaIO/FFMPEGBuilder/pull/5
* https://github.com/JuliaPackaging/BinaryBuilder.jl/commit/7106456295f34a1e7d791b4b2af8f28a41dd260a
* https://github.com/JuliaPackaging/Yggdrasil/pull/73

Close #148