### PR TITLE
[Dependencies] Default `build_version` to the minimum compatible version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -42,6 +42,13 @@ end
     @test getpkg(dep_buildver) == PackageSpec(; name = name, version = build_version)
     @test getcompat(dep_buildver) == "~1.2"
 
+    # the same but only with compat specifier
+    dep_compat = Dependency(PackageSpec(; name); compat = "2, ~$(build_version)")
+    @test Dependency(name, build_version) == dep_compat
+    @test getname(dep_compat) == name
+    @test getpkg(dep_compat) == PackageSpec(; name, version = build_version)
+    @test getcompat(dep_compat) == "2, ~$(build_version)"
+
     # if build_version and compat don't match, an error should be thrown
     @test_throws ArgumentError Dependency(PackageSpec(; name = name), build_version, compat = "2.0")
 


### PR DESCRIPTION
In a `Dependency` we have to specify two versions numbers: the actual build
version and the compat version, which 99.99% of the time are the same.  This is
annoying and error-prone.  With this change the build version defaults to the
minimum compatible version specified by `compat`, if any.

CC: @fingolfin