### PR TITLE
Rename helper function `strip_backslash` -> `strip_path_separator`

### DIFF
--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -115,7 +115,7 @@ Returns the logs directory for the given `prefix`.  If `subdir` is a non-empty s
 directory it is appended to the logdir of the given `prefix`.
 """
 function logdir(prefix::Prefix; subdir::AbstractString="")
-    return strip_backslash(joinpath(prefix, "logs", subdir))
+    return strip_path_separator(joinpath(prefix, "logs", subdir))
 end
 
 """
@@ -262,7 +262,7 @@ function setup(source::SetupSource{GitSource}, targetdir, verbose)
     repo_dir = joinpath(targetdir, name)
     if verbose
         # Need to strip the trailing separator
-        path = strip_backslash(targetdir)
+        path = strip_path_separator(targetdir)
         @info "Cloning $(basename(source.path)) to $(basename(repo_dir))..."
     end
     LibGit2.with(LibGit2.clone(source.path, repo_dir)) do repo
@@ -302,7 +302,7 @@ end
 function setup(source::SetupSource{DirectorySource}, targetdir, verbose)
     mkpath(targetdir)
     # Need to strip the trailing separator also here
-    srcpath = strip_backslash(source.path)
+    srcpath = strip_path_separator(source.path)
     if verbose
         @info "Copying content of $(basename(srcpath)) in $(basename(targetdir))..."
     end
@@ -362,7 +362,7 @@ function setup_workspace(build_path::AbstractString, sources::Vector,
             target = joinpath(srcdir, source.target)
             # Trailing directory separator matters for `basename`, so let's strip it
             # to avoid confusion
-            target = strip_backslash(target)
+            target = strip_path_separator(target)
             setup(source, target, verbose)
         else
             setup(source, srcdir, verbose)

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -6,7 +6,7 @@ extract_fields(x) = Dict(String(name) => getfield(x, name) for name in fieldname
 
 # Trailing directory separator matters for `basename`, so let's strip it to
 # avoid confusion
-strip_backslash(path::AbstractString) = isdirpath(path) ? dirname(path) : path
+strip_path_separator(path::AbstractString) = isdirpath(path) ? dirname(path) : path
 
 function valid_dl_path(path, platform)
     try

--- a/test/compat.jl
+++ b/test/compat.jl
@@ -1,5 +1,5 @@
 using Test
-using BinaryBuilderBase: extract_kwargs, extract_fields, strip_backslash, ArchiveSource
+using BinaryBuilderBase: extract_kwargs, extract_fields, strip_path_separator, ArchiveSource
 using Downloads: RequestError
 @testset "Compat functions" begin
     foo(; kwargs...) = collect(extract_kwargs(kwargs, (:bar, :qux)))
@@ -10,15 +10,15 @@ using Downloads: RequestError
 
     @test extract_fields(ArchiveSource("http://example.org", "this is the hash"; unpack_target = "target")) == Dict("url" => "http://example.org", "hash" => "this is the hash", "unpack_target" => "target")
 
-    @test strip_backslash("/home/wizard") == "/home/wizard"
-    @test strip_backslash("/home/wizard/") == "/home/wizard"
-    @test strip_backslash("/home//wizard///") == "/home//wizard"
-    @test strip_backslash("wizard.jl") == "wizard.jl"
+    @test strip_path_separator("/home/wizard") == "/home/wizard"
+    @test strip_path_separator("/home/wizard/") == "/home/wizard"
+    @test strip_path_separator("/home//wizard///") == "/home//wizard"
+    @test strip_path_separator("wizard.jl") == "wizard.jl"
     # Test integration with `basename`
-    @test basename(strip_backslash("/home/wizard")) == "wizard"
-    @test basename(strip_backslash("/home/wizard/")) == "wizard"
-    @test basename(strip_backslash("/home//wizard///")) == "wizard"
-    @test basename(strip_backslash("wizard.jl")) == "wizard.jl"
+    @test basename(strip_path_separator("/home/wizard")) == "wizard"
+    @test basename(strip_path_separator("/home/wizard/")) == "wizard"
+    @test basename(strip_path_separator("/home//wizard///")) == "wizard"
+    @test basename(strip_path_separator("wizard.jl")) == "wizard.jl"
 end
 
 using BinaryBuilderBase: download_verify, list_tarball_files


### PR DESCRIPTION
`strip_backslash` was a misnomer: what we remove is a forward slash, not a
backward one.  "Path separator" is more accurate though.