### PR TITLE
[Runner] Move `csl_paths(host_platform)` at the beginning of `LD_LIBRARY_PATH`

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2814,27 +2814,27 @@ os = "linux"
     sha256 = "d9bab2d2b19966509a070a92f6f982389d3ab418577a3a17dfbb0f03065216a6"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/PlatformSupport-v2021.1.28/PlatformSupport-x86_64-w64-mingw32.v2021.1.28.x86_64-linux-musl.unpacked.tar.gz"
 
-[["Rootfs.v2021.7.12.x86_64-linux-musl.squashfs"]]
+[["Rootfs.v2021.7.13.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "ff5285a07b28ff11026e779e042bf80283c30129"
+git-tree-sha1 = "5795ee9f2eca2284bfb80611ac2accfc89998e0b"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["Rootfs.v2021.7.12.x86_64-linux-musl.squashfs".download]]
-    sha256 = "a1216c62617a80607bf21aff5e5ae40bb46e8602f6189c87ed8d151d1b59f87f"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2021.7.12/Rootfs.v2021.7.12.x86_64-linux-musl.squashfs.tar.gz"
+    [["Rootfs.v2021.7.13.x86_64-linux-musl.squashfs".download]]
+    sha256 = "1bb755ffdf003fa1a1457cfbc3ad44e770038181e5a1138a54b0d60de507f692"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2021.7.13/Rootfs.v2021.7.13.x86_64-linux-musl.squashfs.tar.gz"
 
-[["Rootfs.v2021.7.12.x86_64-linux-musl.unpacked"]]
+[["Rootfs.v2021.7.13.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "d40d6852338378ec860f6f78b93786bca64e21ca"
+git-tree-sha1 = "56df63e8265adb2316d6599632113da025545434"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["Rootfs.v2021.7.12.x86_64-linux-musl.unpacked".download]]
-    sha256 = "fd628ee10bdfbd093e5ba245eb72a6a07759d5c175529e5d72c3867594db2870"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2021.7.12/Rootfs.v2021.7.12.x86_64-linux-musl.unpacked.tar.gz"
+    [["Rootfs.v2021.7.13.x86_64-linux-musl.unpacked".download]]
+    sha256 = "aa5aef6b4c68b28c135da87d3d0169e142a84b89d556748f3f37d30355b9ca17"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2021.7.13/Rootfs.v2021.7.13.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustBase.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.6.12"
+version = "0.6.13"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -508,7 +508,7 @@ consists of four shards, but that may not always be the case.
 """
 function choose_shards(p::AbstractPlatform;
             compilers::Vector{Symbol} = [:c],
-            rootfs_build::VersionNumber=v"2021.7.12",
+            rootfs_build::VersionNumber=v"2021.7.13",
             ps_build::VersionNumber=v"2021.01.28",
             GCC_builds::Vector{GCCBuild}=available_gcc_builds,
             LLVM_builds::Vector{LLVMBuild}=available_llvm_builds,

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -69,12 +69,8 @@ function ld_library_path(target::AbstractPlatform,
     # If requested, start with our CSL libraries for target/host, but only for architectures
     # that can natively run within this environment
     if csl_paths
-        # Ok, this is incredibly finicky.  If the target has the same architecture as the
-        # host, we should have the host first then the target, otherwise we need to have
-        # target first.
-        platforms = arch(target) == arch(host) ? (host, target) : (target, host)
         append!(paths,
-                unique("/usr/lib/csl-$(libc(p))-$(arch(p))" for p in platforms if Sys.islinux(p) && proc_family(p) == "intel"),
+                unique("/usr/lib/csl-$(libc(p))-$(arch(p))" for p in (host, target) if Sys.islinux(p) && proc_family(p) == "intel"),
                 )
     end
 

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -903,7 +903,7 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
             # We need to push i686 directories before x86_64 ones
             ("i686", "x86_64")
         else
-            ("x86", "i686_64")
+            ("x86_64", "i686")
         end
 
         return join(["/usr/lib/csl-$(libc)-$(arch)" for libc in libcs, arch in archs], ":")

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -395,6 +395,8 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             hash_args = true,
             allow_ccache,
             no_soft_float=arch(p) in ("armv6l", "armv7l"),
+            # Override `LD_LIBRARY_PATH` to avoid external settings mess it up.
+            env=Dict("LD_LIBRARY_PATH"=>""),
         )
     end
 
@@ -406,6 +408,8 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             compile_only_flags=clang_compile_flags!(p),
             link_only_flags=clang_link_flags!(p),
             no_soft_float=arch(p) in ("armv6l", "armv7l"),
+            # Override `LD_LIBRARY_PATH` to avoid external settings mess it up.
+            env=Dict("LD_LIBRARY_PATH"=>""),
         )
     end
 

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -927,12 +927,12 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
         ), ":"),
 
         "LD_LIBRARY_PATH" => join((
-           # Start with a default path
-           "/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib",
+            # Start with our CSL libraries for all architectures that can natively run within this environment
+            csl_paths(host_platform),
+            # Then add default system paths
+            "/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib",
             # Add our loader directories
             "/lib64:/lib",
-            # Add our CSL libraries for all architectures that can natively run within this environment
-            csl_paths(host_platform),
             # Libdir of the host platform, to run programs in `HostBuildDependency`
             "$(host_libdir)",
             # Add our target/host-specific library directories for compiler support libraries

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -169,15 +169,10 @@ end
                 ./test
                 """
                 cmd = `/bin/bash -c "$(test_script)"`
-                if arch(platform) == "i686" && libc(platform) == "musl"
-                    # We can't run this program for this platform
-                    @test_broken run(ur, cmd, iobuff; tee_stream=devnull)
-                else
-                    @test run(ur, cmd, iobuff; tee_stream=devnull)
-                    seekstart(iobuff)
-                    # Test that we get the output we expect
-                    @test endswith(readchomp(iobuff), "Hello World!")
-                end
+                @test run(ur, cmd, iobuff; tee_stream=devnull)
+                seekstart(iobuff)
+                # Test that we get the output we expect
+                @test endswith(readchomp(iobuff), "Hello World!")
                 cleanup_dependencies(prefix, artifact_paths, concrete_platform)
             end
         end
@@ -223,15 +218,10 @@ end
                 ./test
                 """
                 cmd = `/bin/bash -c "$(test_script)"`
-                if arch(platform) == "i686" && libc(platform) == "musl"
-                    # We can't run C++ programs for this platform
-                    @test_broken run(ur, cmd, iobuff; tee_stream=devnull)
-                else
-                    @test run(ur, cmd, iobuff; tee_stream=devnull)
-                    seekstart(iobuff)
-                    # Test that we get the output we expect
-                    @test endswith(readchomp(iobuff), "Hello World!")
-                end
+                @test run(ur, cmd, iobuff; tee_stream=devnull)
+                seekstart(iobuff)
+                # Test that we get the output we expect
+                @test endswith(readchomp(iobuff), "Hello World!")
                 cleanup_dependencies(prefix, artifact_paths, concrete_platform)
             end
         end

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -96,11 +96,12 @@ end
     end
 
     # This tests only that compilers for all platforms can build a simple C program
-    @testset "Compilation - $(platform)" for platform in platforms
+    # TODO: for the time being we only test `cc`, eventually we want to run `gcc` and `clang` separately
+    @testset "Compilation - $(platform) - $(compiler)" for platform in platforms, compiler in ("cc",)
         mktempdir() do dir
             ur = preferred_runner()(dir; platform=platform)
             iobuff = IOBuffer()
-            @test run(ur, `/bin/bash -c "echo 'int main() {return 0;}' | cc -x c -"`, iobuff; tee_stream=devnull)
+            @test run(ur, `/bin/bash -c "echo 'int main() {return 0;}' | $(compiler) -x c -"`, iobuff; tee_stream=devnull)
             seekstart(iobuff)
             @test split(String(read(iobuff)), "\n")[2] == ""
         end

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -130,6 +130,58 @@ end
             end
         end
 
+        @testset "C and link to quadmath - $(platform)" for platform in platforms
+            mktempdir() do dir
+                # Use a recent GCC with libgfortran5
+                options = (preferred_gcc_version=v"9", compilers=[:c])
+                shards = choose_shards(platform; options...)
+                concrete_platform = get_concrete_platform(platform, shards)
+                prefix = setup_workspace(
+                    dir,
+                    [],
+                    concrete_platform,
+                    default_host_platform;
+                )
+                # Install `MPICH_jll` in the `${prefix}` to make sure we can link to
+                # libquadmath without problems, see
+                # https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/157#issuecomment-879263820
+                artifact_paths =
+                    setup_dependencies(prefix,
+                                       [PackageSpec(; name="MPICH_jll", version="3.4.2")],
+                                       concrete_platform, verbose=false)
+                ur = preferred_runner()(prefix.path;
+                                        platform=concrete_platform,
+                                        shards = shards,
+                                        options...)
+                iobuff = IOBuffer()
+                test_c = """
+                #include <stdio.h>
+                int main() {
+                    printf("Hello World!\\n");
+                    return 0;
+                }
+                """
+                test_script = """
+                set -e
+                echo '$(test_c)' > test.c
+                # Make sure we can compile successfully also when linking to libmpifort
+                cc -o test test.c -L\${libdir} -lmpifort -lquadmath
+                ./test
+                """
+                cmd = `/bin/bash -c "$(test_script)"`
+                if arch(platform) == "i686" && libc(platform) == "musl"
+                    # We can't run this program for this platform
+                    @test_broken run(ur, cmd, iobuff; tee_stream=devnull)
+                else
+                    @test run(ur, cmd, iobuff; tee_stream=devnull)
+                    seekstart(iobuff)
+                    # Test that we get the output we expect
+                    @test endswith(readchomp(iobuff), "Hello World!")
+                end
+                cleanup_dependencies(prefix, artifact_paths, concrete_platform)
+            end
+        end
+
         @testset "C++ - $(platform)" for platform in platforms
             mktempdir() do dir
                 # Use an old GCC with libgfortran3
@@ -167,7 +219,7 @@ end
                 echo '$(test_cpp)' > test.cpp
                 # Make sure we can compile successfully also when `\${libdir}` is in the
                 # linker search path
-                g++ -o test test.cpp -L\${libdir}
+                c++ -o test test.cpp -L\${libdir}
                 ./test
                 """
                 cmd = `/bin/bash -c "$(test_script)"`

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -170,10 +170,15 @@ end
                 ./test
                 """
                 cmd = `/bin/bash -c "$(test_script)"`
-                @test run(ur, cmd, iobuff; tee_stream=devnull)
-                seekstart(iobuff)
-                # Test that we get the output we expect
-                @test endswith(readchomp(iobuff), "Hello World!")
+                if arch(platform) == "i686" && libc(platform) == "musl"
+                    # We can't run this program for this platform
+                    @test_broken run(ur, cmd, iobuff; tee_stream=devnull)
+                else
+                    @test run(ur, cmd, iobuff; tee_stream=devnull)
+                    seekstart(iobuff)
+                    # Test that we get the output we expect
+                    @test endswith(readchomp(iobuff), "Hello World!")
+                end
                 cleanup_dependencies(prefix, artifact_paths, concrete_platform)
             end
         end
@@ -219,10 +224,15 @@ end
                 ./test
                 """
                 cmd = `/bin/bash -c "$(test_script)"`
-                @test run(ur, cmd, iobuff; tee_stream=devnull)
-                seekstart(iobuff)
-                # Test that we get the output we expect
-                @test endswith(readchomp(iobuff), "Hello World!")
+                if arch(platform) == "i686" && libc(platform) == "musl"
+                    # We can't run C++ programs for this platform
+                    @test_broken run(ur, cmd, iobuff; tee_stream=devnull)
+                else
+                    @test run(ur, cmd, iobuff; tee_stream=devnull)
+                    seekstart(iobuff)
+                    # Test that we get the output we expect
+                    @test endswith(readchomp(iobuff), "Hello World!")
+                end
                 cleanup_dependencies(prefix, artifact_paths, concrete_platform)
             end
         end

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -65,7 +65,7 @@ end
             @test run(ur, `/bin/bash -c "echo test"`, iobuff)
             seek(iobuff, 0)
             # Test that we get the output we expect (e.g. the second line is `test`)
-            @test split(String(read(iobuff)), "\n")[2] == "test"
+            @test readlines(iobuff)[2] == "test"
         end
     end
 
@@ -259,7 +259,7 @@ end
             iobuff = IOBuffer()
             @test !run(ur, cmd, iobuff; tee_stream=devnull)
             seekstart(iobuff)
-            @test split(String(read(iobuff)), "\n")[2] == "Cannot force an architecture"
+            @test readlines(iobuff)[2] == "Cannot force an architecture"
 
             ur = preferred_runner()(dir; platform=platform, lock_microarchitecture=false)
             iobuff = IOBuffer()
@@ -277,7 +277,7 @@ end
             iobuff = IOBuffer()
             @test !run(ur, cmd, iobuff; tee_stream=devnull)
             seekstart(iobuff)
-            lines = split(String(read(iobuff)), "\n")
+            lines = readlines(iobuff)
             @test lines[2] == "You used one or more of the unsafe flags: -Ofast, -ffast-math, -funsafe-math-optimizations"
             @test lines[3] == "Please repent."
 


### PR DESCRIPTION
This should make it easier to run applications we build with the host toolchain.  CC: @vchuravy 