### PR TITLE
[Rootfs] Do not use old GCC versions with new LLVM for FreeBSD

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -114,6 +114,15 @@ end
         # With no constraints, we should get them all back
         @test gcc_version(Platform("x86_64", "linux"), available_gcc_builds) == getversion.(available_gcc_builds)
 
+        # Filter for FreeBSD.  No version of LLVM is specified, all versions
+        # should be available
+        @test gcc_version(Platform("x86_64", "freebsd"), available_gcc_builds) == getversion.(available_gcc_builds)
+        # With LLVM 11 all versions of GCC are still allowed
+        @test gcc_version(Platform("x86_64", "freebsd"), available_gcc_builds; llvm_version=v"11") == getversion.(available_gcc_builds)
+        # With LLVM 12 we can only use GCC 6+
+        @test gcc_version(Platform("x86_64", "freebsd"), available_gcc_builds; llvm_version=v"12") ==
+            filter(≥(v"6"), getversion.(available_gcc_builds))
+
         # libgfortran v3 and libstdcxx 22 restrict us to only v4.8, v5.2 and v6.1
         p = Platform("x86_64", "linux"; libgfortran_version=v"3", libstdcxx_version=v"3.4.22")
         @test gcc_version(p, available_gcc_builds) == [v"4.8.5", v"5.2.0", v"6.1.0"]


### PR DESCRIPTION
LLVMBootstrap 12 needs to be built with GCCBootstrap ≥ 7.  However, when
building for FreeBSD with LLVMBootstrap 12 we can't use `ld` from binutils <
2.26 (which corresponds to GCCBootstrap < 6) to link some object files.  The
solution is to not allow old GCCBootstrap with new versions of LLVMBootstrap for
FreeBSD.

For reference see #158.