### PR TITLE
[Runner] Push `/opt/${target}/${target}/lib{,64}` to linker search path

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.6.11"
+version = "0.6.12"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"


### PR DESCRIPTION
When compiling with GCC this makes sure its libraries have precedence over
anything else, in particular other compiler libraries that may be elsewhere, for
example `CompilerSupportLibraries_jll` used as dependency during the build.

Fix #163.

Note: I ran the tests of BinaryBuilder on this branch in https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1032, seems all good.