### PR TITLE
Set version to 1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.6.13"
+version = "1.0.0"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"


### PR DESCRIPTION
As far as I know, #166 is technically a breaking change, as it removes FreeBSD 11 artifacts. Thus we would need to tag a breaking release anyway, but if we're going to do that, we'd might as well tag 1.0 given the general stability of BBB. Thoughts?