### PR TITLE
[BuildToolchains] Teach CMake that libraries go in `bin/` on Windows

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/BuildToolchains.jl
+++ b/src/BuildToolchains.jl
@@ -65,6 +65,7 @@ function toolchain_file(bt::CMake, p::AbstractPlatform; is_host::Bool=false)
             \${CMAKE_SYSROOT}/System/Library/PrivateFrameworks
         )
         set(CMAKE_INSTALL_PREFIX \$ENV{prefix})
+        set(CMAKE_INSTALL_LIBDIR lib)
 
         set(CMAKE_C_COMPILER   /opt/bin/$(target)/$(aatarget)-$(c_compiler(bt)))
         set(CMAKE_CXX_COMPILER /opt/bin/$(target)/$(aatarget)-$(cxx_compiler(bt)))
@@ -89,6 +90,7 @@ function toolchain_file(bt::CMake, p::AbstractPlatform; is_host::Bool=false)
 
         set(CMAKE_SYSROOT /opt/$(aatarget)/$(aatarget)/sys-root/)
         set(CMAKE_INSTALL_PREFIX \$ENV{prefix})
+        set(CMAKE_INSTALL_LIBDIR $(Sys.iswindows(p) ? "bin" : "lib"))
 
         set(CMAKE_C_COMPILER   /opt/bin/$(target)/$(aatarget)-$(c_compiler(bt)))
         set(CMAKE_CXX_COMPILER /opt/bin/$(target)/$(aatarget)-$(cxx_compiler(bt)))


### PR DESCRIPTION
Hopefully we'll see fewer

```
Simple buildsystem detected; Moving all `.dll` files to `bin`!
```

warnings with CMake-based project, as long as people don't decide to override
the destination directory.