### PR TITLE
add installed_shards() function to output downloaded artifacts on system

### DIFF
--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -970,8 +970,7 @@ end
 Return a vector of compiler shards currently downloaded on the local system
 """
 function installed_shards()
-    hashes = shard_source_artifact_hash.(all_compiler_shards())
-    idx = artifact_exists.(hashes)
+    idx = artifact_exists.(shard_source_artifact_hash.(all_compiler_shards()))
 
     return all_compiler_shards()[idx]
 end

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -964,3 +964,14 @@ function unmount_shards(ur::Runner; verbose::Bool = false)
     catch
     end
 end
+
+"""
+    installed_shards()
+Return a vector of compiler shards currently downloaded on the local system
+"""
+function installed_shards()
+    hashes = shard_source_artifact_hash.(all_compiler_shards())
+    idx = artifact_exists.(hashes)
+
+    return all_compiler_shards()[idx]
+end


### PR DESCRIPTION
This PR adds a function `installed_shards()` that outputs a vector of `CompilerShard`s that are currently download and installed on a user's system using the stdlib `Artifacts.artifact_exists()`.

I ran into two situations where this could be useful
1. I downloaded many OS/CompilerVersion shards doing one-off testing and filled up my hard drive. Having this, I would be able to reference which shards I know I use consistently vs ones that could be deleted (still have to manually search and delete).
2. The [Artifact.toml](https://github.com/JuliaPackaging/BinaryBuilderBase.jl/commit/46437bea72d02e5186d16f215b125cd004f52c84) for BBB gets updated and I am trying to see if I have an old version downloaded or the newest version.

Things this can't do:
If the BBB `Artifact.toml` is updated, this won't know anything about the older versions anymore, so those shards would stay downloaded but not show up anymore (freebsd v11 in the link above).

I wasn't sure if this was worth exporting, but `BinaryBuilderBase.installed_shards()` is easy enough to type.
~I don't know if/how this should be tested, so marking as draft for now?~ Other non-exported functions don't seem to be in tests either.