### PR TITLE
[Runner] Prefix error messages in wrappers with `BinaryBuilder`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -219,7 +219,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         if lock_microarchitecture
             write(io, raw"""
                       if [[ " ${ARGS[@]} " == *"-march="* ]]; then
-                          echo "Cannot force an architecture" >&2
+                          echo "BinaryBuilder: Cannot force an architecture" >&2
                           exit 1
                       fi
                       """)
@@ -229,7 +229,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         if no_soft_float
             write(io, raw"""
                       if [[ " ${ARGS[@]} " == *"-mfloat-abi=soft"* ]]; then
-                          echo "${target} platform does not support soft-float ABI" >&2
+                          echo "BinaryBuilder: ${target} platform does not support soft-float ABI" >&2
                           exit 1
                       fi
                       """)
@@ -239,7 +239,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         if length(unsafe_flags) >= 1
             write(io, """
             if [[ "\${ARGS[@]}" =~ \"$(join(unsafe_flags, "\"|\""))\" ]]; then
-                echo -e \"You used one or more of the unsafe flags: $(join(unsafe_flags, ", "))\\nPlease repent.\" >&2
+                echo -e \"BinaryBuilder: You used one or more of the unsafe flags: $(join(unsafe_flags, ", "))\\nPlease repent.\" >&2
                 exit 1
             fi
             """)

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -270,7 +270,7 @@ end
             iobuff = IOBuffer()
             @test !run(ur, cmd, iobuff; tee_stream=devnull)
             seekstart(iobuff)
-            @test readlines(iobuff)[2] == "Cannot force an architecture"
+            @test readlines(iobuff)[2] == "BinaryBuilder: Cannot force an architecture"
 
             ur = preferred_runner()(dir; platform=platform, lock_microarchitecture=false)
             iobuff = IOBuffer()
@@ -289,7 +289,7 @@ end
             @test !run(ur, cmd, iobuff; tee_stream=devnull)
             seekstart(iobuff)
             lines = readlines(iobuff)
-            @test lines[2] == "You used one or more of the unsafe flags: -Ofast, -ffast-math, -funsafe-math-optimizations"
+            @test lines[2] == "BinaryBuilder: You used one or more of the unsafe flags: -Ofast, -ffast-math, -funsafe-math-optimizations"
             @test lines[3] == "Please repent."
 
             ur = preferred_runner()(dir; platform=platform, allow_unsafe_flags=true)


### PR DESCRIPTION
This makes it clearer where the messages come from.

Ref: https://github.com/JuliaPackaging/Yggdrasil/pull/3614#issuecomment-944913439.
CC: @Moelf