### PR TITLE
Make BinaryBuilderBase compatible with v1.6 only

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ OutputCollectors = "0.1"
 Scratch = "1.0"
 SimpleBufferStream = "1"
 Tar = "1.7"
-julia = "1.6"
+julia = "~1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
There are a few things broken in BBB with Julia v1.7+.  I started fixing them #129, but got stuck in Pkg internals (which I don't think have been ever really fixed).  I tried to look again in them today and found there are even more broken things, always because of changes in Pkg internals.  Unless someone has the bandwidth to go through all of them now, I think the best thing to do is to simply tell the truth: this package only works in Julia v1.6.

If it's accepted, I'll do a PR in the General registry as well to set the upper bound of compat.