### PR TITLE
Add field to dependencies to filter them by platform

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.0.4"
+version = "1.1.0"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/Dependencies.jl
+++ b/src/Dependencies.jl
@@ -1,7 +1,8 @@
 using UUIDs
 
 export Dependency, BuildDependency, HostBuildDependency,
-    is_host_dependency, is_target_dependency, is_build_dependency, is_runtime_dependency
+    is_host_dependency, is_target_dependency, is_build_dependency, is_runtime_dependency,
+    filter_platforms
 
 
 # Pkg.PackageSpec return different types in different Julia versions so...
@@ -170,6 +171,14 @@ end
 
 getname(x::PkgSpec) = x.name
 getname(x::AbstractDependency) = getname(getpkg(x))
+
+"""
+    filter_platforms(deps::AbstractVector{<:AbstractDependency}, p::AbstractPlatform)
+
+Filter the dependencies `deps` which are compatible with platform `p`.
+"""
+filter_platforms(deps::AbstractVector{<:AbstractDependency}, p::AbstractPlatform) =
+    [dep for dep in deps if any(x -> platforms_match(x, p), dep.platforms)]
 
 # Wrapper around `Pkg.Types.registry_resolve!` which keeps the type of the
 # dependencies.  TODO: improve this

--- a/src/Dependencies.jl
+++ b/src/Dependencies.jl
@@ -248,7 +248,9 @@ for (type, type_descr) in ((Dependency, "dependency"), (BuildDependency, "buildd
                                "compat" => getcompat(d),
                                "version-major" => major(version(d)),
                                "version-minor" => minor(version(d)),
-                               "version-patch" => patch(version(d)))
+                               "version-patch" => patch(version(d)),
+                               "platforms" => triplet.(d.platforms),
+                               )
 end
 
 # When deserialiasing the JSON file, the dependencies are in the form of
@@ -261,12 +263,13 @@ function dependencify(d::Dict)
         version = VersionNumber(d["version-major"], d["version-minor"], d["version-patch"])
         version = version == v"0" ? nothing : version
         spec = PackageSpec(; name = d["name"], uuid = uuid, version = version)
+        platforms = parse_platform.(d["platforms"])
         if d["type"] == "dependency"
-            return Dependency(spec; compat = compat)
+            return Dependency(spec; compat, platforms)
         elseif d["type"] == "builddependency"
-            return BuildDependency(spec)
+            return BuildDependency(spec; platforms)
         elseif d["type"] == "hostdependency"
-            return HostBuildDependency(spec)
+            return HostBuildDependency(spec; platforms)
         end
     end
     error("Cannot convert to dependency")

--- a/src/Dependencies.jl
+++ b/src/Dependencies.jl
@@ -172,7 +172,7 @@ filter_platforms(deps::AbstractVector{<:AbstractDependency}, p::AbstractPlatform
 function registry_resolve!(ctx, dependencies::Vector{<:AbstractDependency})
     resolved_dependencies = Pkg.Types.registry_resolve!(ctx, getpkg.(dependencies))
     for idx in eachindex(dependencies)
-        dependencies[idx] = typeof(dependencies[idx])(resolved_dependencies[idx])
+        dependencies[idx] = typeof(dependencies[idx])(resolved_dependencies[idx]; filter_platforms=dependencies[idx].filter_platforms)
     end
     return dependencies
 end

--- a/src/Platforms.jl
+++ b/src/Platforms.jl
@@ -39,6 +39,11 @@ Get the executable extension for the given Platform.  Includes the leading `.`.
 platform_exeext(p::AbstractPlatform) = Sys.iswindows(p) ? ".exe" : ""
 
 
+# Helper parsing function: it extends `parse(Platform, p)` by supporting
+# `AnyPlatform` as well.
+parse_platform(p::String) = p == "any" ? AnyPlatform() : parse(Platform, p; validate_strict=true)
+
+
 # Recursively test for key presence in nested dicts
 function haskeys(d, keys...)
     for key in keys

--- a/test/platforms.jl
+++ b/test/platforms.jl
@@ -53,6 +53,10 @@ end
         )
     @test BinaryBuilderBase.choose_shards(AnyPlatform()) == BinaryBuilderBase.choose_shards(default_host_platform)
     @test BinaryBuilderBase.aatriplet(AnyPlatform()) == BinaryBuilderBase.aatriplet(default_host_platform)
+
+    # Make sure `AnyPlatform` matches all platforms we can possibly support.
+    @test all(p -> platforms_match(AnyPlatform(), p),
+              expand_microarchitectures(expand_gfortran_versions(expand_cxxstring_abis(supported_platforms(; experimental=true)))))
 end
 
 @testset "Target properties" begin


### PR DESCRIPTION
This let us declare that certain dependencies are needed at build/runtime only
on some platforms.

First part to address #174, next part will be in BinaryBuilder (I have a somewhat working version locally, but need to figure out a couple of things not working as expected).  Opening as draft for the time being to ask for feedback, especially about names (I'm not really fond of the name `filter_platforms`, which is also used for both the field and the function to filter the vector of dependencies).  After settling on names and API I'll add documentation and tests.

You can find a first proof-of-concept at https://github.com/giordano/NativeFileDialog_jll.jl (note: I'll probably delete the repo after this work is done).  You can see that GTK3_jll is in the [project](https://github.com/giordano/NativeFileDialog_jll.jl/blob/6ade8b1d2155ad93a3a61b242980c267b6afe927/Project.toml) because we can't have conditional dependencies, but it isn't loaded for the [macOS wrapper](https://github.com/giordano/NativeFileDialog_jll.jl/blob/6ade8b1d2155ad93a3a61b242980c267b6afe927/src/wrappers/aarch64-apple-darwin.jl), while it is for the [Linux one](https://github.com/giordano/NativeFileDialog_jll.jl/blob/6ade8b1d2155ad93a3a61b242980c267b6afe927/src/wrappers/x86_64-linux-gnu.jl).