### PR TITLE
add Base.isless for ordering ExecutableProduct vs LibraryProduct

### DIFF
--- a/src/Products.jl
+++ b/src/Products.jl
@@ -494,6 +494,7 @@ function locate(fp::FileProduct, prefix::Prefix; platform::AbstractPlatform = Ho
 end
 
 # Necessary to get the products in the wrappers always sorted consistently
+Base.isless(x::ExecutableProduct, y::LibraryProduct) = true
 Base.isless(x::Product, y::Product) = isless(variable_name(x), variable_name(y))
 Base.sort(d::Dict{Product}) = sort(collect(d), by = first)
 

--- a/src/Products.jl
+++ b/src/Products.jl
@@ -494,7 +494,8 @@ function locate(fp::FileProduct, prefix::Prefix; platform::AbstractPlatform = Ho
 end
 
 # Necessary to get the products in the wrappers always sorted consistently
-Base.isless(x::ExecutableProduct, y::LibraryProduct) = true
+Base.isless(x::LibraryProduct, y::ExecutableProduct) = true
+Base.isless(x::ExecutableProduct, y::LibraryProduct) = false
 Base.isless(x::Product, y::Product) = isless(variable_name(x), variable_name(y))
 Base.sort(d::Dict{Product}) = sort(collect(d), by = first)
 

--- a/test/products.jl
+++ b/test/products.jl
@@ -25,12 +25,12 @@ const platform = HostPlatform()
 
     # Test sorting of products....
     @test sort([LibraryProduct("libbar", :libbar), ExecutableProduct("foo", :foo), FrameworkProduct("buzz", :buzz)]) ==
-        [FrameworkProduct("buzz", :buzz), ExecutableProduct("foo", :foo), LibraryProduct("libbar", :libbar)]
+        [FrameworkProduct("buzz", :buzz), LibraryProduct("libbar", :libbar), ExecutableProduct("foo", :foo)]
     # ...and products info
     p1 = LibraryProduct(["libchafa"], :libchafa, ) => Dict("soname" => "libchafa.so.0","path" => "lib/libchafa.so")
     p2 = ExecutableProduct(["chafa"], :chafa, ) => Dict("path" => "bin/chafa")
     products_info = Dict{Product,Any}(p1, p2)
-    @test sort(products_info) == [p2, p1]
+    @test sort(products_info) == [p1, p2]
 
     temp_prefix() do prefix
         # Test that basic satisfication is not guaranteed


### PR DESCRIPTION
This PR adds an `isless` method for comparing `ExecutableProduct` and `LibraryProduct` such that `ExecutableProduct`s always come before `LibraryProduct`s. This is in support of https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/1109. This seemed like the more appropriate repo to add this particular method compared to regular `BinaryBuilder`

Example Input:
```
#from https://github.com/JuliaPackaging/Yggdrasil/blob/master/U/unixODBC/build_tarballs.jl
products = [
    LibraryProduct("libodbc", :libodbc),
    ExecutableProduct("odbc_config", :odbc_config),
    LibraryProduct("libodbcinst", :libodbcinst),
    ExecutableProduct("isql", :isql),
    ExecutableProduct("iusql", :iusql),
    ExecutableProduct("odbcinst", :odbcinst),
    LibraryProduct("libodbccr", :libodbccr),
    ExecutableProduct("slencheck", :slencheck),
    ExecutableProduct("dltest", :dltest)
]
```
Current behavior (sort on variable name only):

```
julia> sort(products)
9-element Vector{Product}:
 ExecutableProduct(["dltest"], :dltest, nothing)
 ExecutableProduct(["isql"], :isql, nothing)
 ExecutableProduct(["iusql"], :iusql, nothing)
 LibraryProduct(["libodbc"], :libodbc, String[], false, Symbol[])
 LibraryProduct(["libodbccr"], :libodbccr, String[], false, Symbol[])
 LibraryProduct(["libodbcinst"], :libodbcinst, String[], false, Symbol[])
 ExecutableProduct(["odbc_config"], :odbc_config, nothing)
 ExecutableProduct(["odbcinst"], :odbcinst, nothing)
 ExecutableProduct(["slencheck"], :slencheck, nothing)
```

After this PR(sort on Executable/Library and then variable name):
```
julia> sort(products)
9-element Vector{Product}:
 ExecutableProduct(["dltest"], :dltest, nothing)
 ExecutableProduct(["isql"], :isql, nothing)
 ExecutableProduct(["iusql"], :iusql, nothing)
 ExecutableProduct(["odbc_config"], :odbc_config, nothing)
 ExecutableProduct(["odbcinst"], :odbcinst, nothing)
 ExecutableProduct(["slencheck"], :slencheck, nothing)
 LibraryProduct(["libodbc"], :libodbc, String[], false, Symbol[])
 LibraryProduct(["libodbccr"], :libodbccr, String[], false, Symbol[])
 LibraryProduct(["libodbcinst"], :libodbcinst, String[], false, Symbol[])
```