### PR TITLE
Clear out artifacts destdir path if it already exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: Julia ${{ matrix.julia-version }} - x64 - runner ${{ matrix.runner }} - SquashFS ${{ matrix.squashfs }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     env:
       BINARYBUILDER_RUNNER: ${{ matrix.runner }}

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -512,9 +512,7 @@ function setup_dependencies(prefix::Prefix, dependencies::Vector{PkgSpec}, platf
             # Copy the artifact from the global installation location into this build-specific artifacts collection
             src_path = Pkg.Artifacts.artifact_path(Base.SHA1(meta["git-tree-sha1"]))
             dest_path = joinpath(prefix, triplet(platform), "artifacts", basename(src_path))
-            if isdir(dest_path)
-                rm(dest_path; recursive=true)
-            end
+            rm(dest_path; force=true, recursive=true)
             cp(src_path, dest_path)
 
             # Keep track of our dep paths for later symlinking

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -512,6 +512,9 @@ function setup_dependencies(prefix::Prefix, dependencies::Vector{PkgSpec}, platf
             # Copy the artifact from the global installation location into this build-specific artifacts collection
             src_path = Pkg.Artifacts.artifact_path(Base.SHA1(meta["git-tree-sha1"]))
             dest_path = joinpath(prefix, triplet(platform), "artifacts", basename(src_path))
+            if isdir(dest_path)
+                rm(dest_path; recursive=true)
+            end
             cp(src_path, dest_path)
 
             # Keep track of our dep paths for later symlinking


### PR DESCRIPTION
Since we're doing the symlinking now, there's no reason not to just
have BinaryBuilderBase manage this directory and clear it out if it
already exists. This avoids having to manually clear out existing
directories in `bb add`.