### PR TITLE
Upgrade Rust to v1.57.0 and JIT-generate Cargo config file

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2814,28 +2814,6 @@ os = "linux"
     sha256 = "aa5aef6b4c68b28c135da87d3d0169e142a84b89d556748f3f37d30355b9ca17"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2021.7.13/Rootfs.v2021.7.13.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustBase.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "bcd3deb4047a5fdae6abf9808da90e7de1be3924"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustBase.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "bb832c8e266f9e2b80137662c64da5a060895711d61468cc02134f08dd45675a"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.43.0/RustBase.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustBase.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "dd295f16022f44a6e2a11659686210653b3dd734"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustBase.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "add2085c6cb4a5822b2796c1060b0ffeb05be381a8effaa4ce655da0bbe27fef"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.43.0/RustBase.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
-
 [["RustBase.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "bc607dbb4a6b8032c5782dbc5116bbe2f5644add"
@@ -2880,28 +2858,6 @@ os = "linux"
     sha256 = "3f1947fd450d643c1c914da2293534b0bd45e5f4096983cc964f032efc065ac8"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "679466147d4a4f83e448f0b64d8045178d3387d9"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "a1a80df576a306cade3c623b3b7a06a9350e69f35d8fba00d4f425ba6008ff00"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "16ab1df0afc72fa428040bda5ee51521390936a1"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "f4e3d1adb8944c745c29157b98b0d7c0b5061f990e5544716d171e9dd84310e4"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
-
 [["RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "05b87e9dbb0c783a41f432476d3661643b659edb"
@@ -2923,28 +2879,6 @@ os = "linux"
     [["RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked".download]]
     sha256 = "7d908d8bda29e04315568689f1ccd6e85405087669b94704231736ad0feedaa4"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
-
-[["RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "30a1e761cdef918a3097dfb33de3b4bd405e4ea4"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "46b76ea4e5e3fc59028c8a4f2aa0e118fd3763cb573cc9d25f8d4d0346e97eed"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "26b111ba5a0cf9f962e5903117948abb7b04425d"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "a5d872c32408a61c8e94529a94242dc8528cefa09a134ef517901c569a1ca77f"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -2968,28 +2902,6 @@ os = "linux"
     sha256 = "a7ea89ec1619a754f6e2573caba29f5fa5b65493c62320a41f431e3fd1d5600b"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "39a97ffc947b02fca6e70b856aeaf422354ece8e"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "f351c0db74c098e6833f3f57aa0e8792eef8f73635902618291350321df16afa"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "023f66ad795e940becb6138192644099f8671368"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "c2759d548d070d3bd5e5006905d85aa62849ba634f89ad00e213507397f19fcc"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
-
 [["RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "199b6e8f90be5f971d80ee6d5702a9b260e246fa"
@@ -3011,28 +2923,6 @@ os = "linux"
     [["RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.unpacked".download]]
     sha256 = "ffd73b9a195ba5b2af4f9f9e3242523d2a7b8e0a9f0cb3b33081063c9c881bd9"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1+0/RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
-
-[["RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "917d476f3315fc49198424c4035182d974f66ee7"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "5085bd1f498e2a0526a05fa3af7c5536be1709db9986ae08238b07596d912b20"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "4b9b489d949a015e187a7cea487b67037b9e1584"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "493f5615e52aa5c417064d90adab8311706450ea6568757e43b5a8dd2f163ad0"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -3056,28 +2946,6 @@ os = "linux"
     sha256 = "3b55cf03789c698a9e741535a962847f2efb43114e238336308213b475f62578"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1+0/RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "becc59b46459da2374e3aeb2fbbaf3a43bc84f6e"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "e34a6c7837e65484fe686e4718343ea6bafec48af5e8fd88d90d7c9c962a7332"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "8f0fea4f3872d8b07a6c50a832411e12f7f6279f"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "56b3f0bae3fcfdd5b9903d22c5f478cd4f252d2b03e8fc67a610856e3e072746"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
-
 [["RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "6cef979bc23000a2879d60bf33b3a9fbc1d4c9f1"
@@ -3099,28 +2967,6 @@ os = "linux"
     [["RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked".download]]
     sha256 = "b9cbde430b929a7defbc57b5197d282e527fbd4fdb3a4baa00fc31708da43c30"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
-
-[["RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "26e7c797182f6583b2d015b36499b89c8ea10ab7"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "01fc4f0fff3185dfc7ff813e8d7d8782e16cea01aeeb491a5f8abb7130a5788e"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "57eeeccc7030cf901d882e1eafffed57b5db3170"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "cca35b096adc9e22b1ea39922165db94039fa2d064fe9ab0252af9481f37d296"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -3144,28 +2990,6 @@ os = "linux"
     sha256 = "e648f2069c48adf65d436b2f7f5427767a0098e6e28bd63772014a29aea4ba47"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "0017c72b4278ffc09a567f13efd22e1d9d4898e8"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "26c47bd5651a2bc6eca94dfbeca1f6fb226ebaf427ea8d2a6cbf58777bd3969d"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "846fa13405e3785b34b44ce1b70e183406e3f0f6"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "a23e1f638397434552be742082ae3f75b95d616d4a5679c6ff5be7b1d381d8b8"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
-
 [["RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "0db4b2b650a7e058870a732fbd496cbf49aa9fec"
@@ -3187,28 +3011,6 @@ os = "linux"
     [["RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked".download]]
     sha256 = "fa4261f70bc07e118ea398d6cb4c44a53d0ab8fa0a45f8cdf83caaac765bde16"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
-
-[["RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "52a662a89fc8a94eb2ae8e85e9f7b94e959e70e1"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "a0563b90c2133f09a78aac561e7bf2551c8517fcb8d5969f519f90add8088839"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "a6c41c650d95c81fd116c15d86b22408a59702bc"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "eeac1c672ccab57e827d71bdb851f4a75cbfc8b0742c27b02f54a0cde6004463"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -3232,28 +3034,6 @@ os = "linux"
     sha256 = "c6d31476c1adce971db2279413daca3d2eb85c7c4b415d8903bbc782db619ebc"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "4ed3e360244bab5c293fc5300c8c7ed4459f5522"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "a33672ef7f1d45b162daa742428ca2f24f9730d63ce33f979a17121a94612d82"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "15736e29aeb9d7c8973f49061b52b56bc718c017"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "57539536a01b5a95d8c092bfa3087dc7cdffcfbce3e291b4c387227bd134c0e5"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
-
 [["RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "e3f99f63540a645d8a5fa1b8703a909ca8e2026b"
@@ -3275,28 +3055,6 @@ os = "linux"
     [["RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked".download]]
     sha256 = "e5878e6d73024be1002d5217091878ed0a8860a94a3f15dc6a601245237dfdf3"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
-
-[["RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "c3a50fda3bb1067df6ac25068057f4b5971dbdae"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "822dbdbfb4d4acc592e62aea3d56eaecf8d0a4eab9478690ad22469016b2ebc3"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "f132381d2f8f7bd9d70143b03d2317eba70f0820"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "3693828b8f3fccbecaf213c4d8717a95a7329f1ce3ed644c4be5f0a472e77dc4"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -3320,28 +3078,6 @@ os = "linux"
     sha256 = "1ece03664f540a428b66f08c04801f64200b52172302d6d0f6762899a47ae897"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "5e867eaf4198438e6e2b964a92a359a28438823f"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "f70d83ed5b9726302324166ee905c5dd27d1b3b9d2de3161bc9237e05af60596"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "a833b9311c9d06cbacddc8ea769d8a2840041bdd"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "fe5a583c78964ee49108a80e9d1f234540a92ddf3d8f1e540f32a6f5ebfd50a6"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
-
 [["RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "323e2240a1b3e0356e1e910c2c38feec683401e4"
@@ -3364,28 +3100,6 @@ os = "linux"
     sha256 = "f3e2abc52ee2825b17d5d8c1cd90b5e7054b86fed065fd612615cc131e3d71c5"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "23e04df431284abd87005e5550860a91f695e436"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "618b3e401738e087933c7f3a586b1a1727767d908d281104413c0f73f5288ead"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "da5437f319d2302759b3cf575b6988857ed3b042"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "8aacd26cf5e54418403779a1d4a7a9a19797ed90c3fe034015fc4443108fbb61"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
-
 [["RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "01f03c83d75ac67819f5d963fc071bea2e2da899"
@@ -3407,28 +3121,6 @@ os = "linux"
     [["RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.unpacked".download]]
     sha256 = "2a8ebbe024a087b3629a5d26e39fb757b8acc45c57d92e86b7c1742ec37a6aa9"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
-
-[["RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "4f995d8f9a0d1f1631f93e138ed0009ded0a8c81"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "1f3d002a69d7d6f993accb061c74b190fa4bb67e5da066ca1bc171dd42ca8ae7"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "7d86454dbb01713aa4ba403dbd9ea4c025608f28"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "9302af586d24b8c60fe5268c2646c6ad4ac488458244219b8c5d7d3076701b89"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2836,6 +2836,50 @@ os = "linux"
     sha256 = "add2085c6cb4a5822b2796c1060b0ffeb05be381a8effaa4ce655da0bbe27fef"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.43.0/RustBase.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustBase.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "bc607dbb4a6b8032c5782dbc5116bbe2f5644add"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustBase.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "de692f3cbc235701608300721db6c43c754936204b8b31f4f8709ff22618bbd8"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.56.1/RustBase.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustBase.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "e6b8dda037c6b3b747d71f1cde25cf79e2a271de"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustBase.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "21b801b9f6acd7d3f5e334974d4165637e8eb8960cce6a99eccdf1d59edc3c28"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.56.1/RustBase.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "6e4e76e922d1c685da8f0edc2d4615589544cf17"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "1ff64974af9194dd2bb3b752dfcd0caf30b49e957e1a03f7b8bb79309d44b92a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "5957e8124cd32bf834eb302d9e7d16c648afc8f2"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "3f1947fd450d643c1c914da2293534b0bd45e5f4096983cc964f032efc065ac8"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "679466147d4a4f83e448f0b64d8045178d3387d9"
@@ -2857,6 +2901,28 @@ os = "linux"
     [["RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "f4e3d1adb8944c745c29157b98b0d7c0b5061f990e5544716d171e9dd84310e4"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-aarch64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "05b87e9dbb0c783a41f432476d3661643b659edb"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "9bcd51d6d391988f9420659bbb87f467ebfa05d500f613f3cdbdff4e068c9f16"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "5f11ac937d6cf3a1f4a2a946fab72f5047d039f9"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "7d908d8bda29e04315568689f1ccd6e85405087669b94704231736ad0feedaa4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -2880,6 +2946,28 @@ os = "linux"
     sha256 = "a5d872c32408a61c8e94529a94242dc8528cefa09a134ef517901c569a1ca77f"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-aarch64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "f34e54bae8a5d34d1c3e2532c313a59791fca71b"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "cc0247a6d40b84486dfce80ec9acf1e30f5d35535007da7ffc916b40bbebab7d"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "0075024bd660067db98c6fc4e57660646e99597b"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "a7ea89ec1619a754f6e2573caba29f5fa5b65493c62320a41f431e3fd1d5600b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "39a97ffc947b02fca6e70b856aeaf422354ece8e"
@@ -2901,6 +2989,28 @@ os = "linux"
     [["RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "c2759d548d070d3bd5e5006905d85aa62849ba634f89ad00e213507397f19fcc"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-armv7l-linux-gnueabihf.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "199b6e8f90be5f971d80ee6d5702a9b260e246fa"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "e402a018ef50085aa60792b26d7d8cc0a351bf8f33091b6f611129b7405aa116"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1+0/RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "0d1abb3132be195e45db8eb2365c072f39bba538"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "ffd73b9a195ba5b2af4f9f9e3242523d2a7b8e0a9f0cb3b33081063c9c881bd9"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1+0/RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -2924,6 +3034,28 @@ os = "linux"
     sha256 = "493f5615e52aa5c417064d90adab8311706450ea6568757e43b5a8dd2f163ad0"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-armv7l-linux-musleabihf.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "d85715815f4a9dc202b75ba495d42b5aa22176f2"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "00e4f4985afb7f268ba6f2de9375b73cc139046f2e5b72f4d0e3606ad943a252"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1+0/RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "5b5aabb64a3d725e239cfdb1c32eef14d518a9ab"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "3b55cf03789c698a9e741535a962847f2efb43114e238336308213b475f62578"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1+0/RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "becc59b46459da2374e3aeb2fbbaf3a43bc84f6e"
@@ -2945,6 +3077,28 @@ os = "linux"
     [["RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "56b3f0bae3fcfdd5b9903d22c5f478cd4f252d2b03e8fc67a610856e3e072746"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "6cef979bc23000a2879d60bf33b3a9fbc1d4c9f1"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "8e012d132ec4d65029903b30da97865da035bdd455d00895e52a1753e198eaef"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "55bb1f1c59667f9e7d01567b03025d1b3aba74eb"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "b9cbde430b929a7defbc57b5197d282e527fbd4fdb3a4baa00fc31708da43c30"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -2968,6 +3122,28 @@ os = "linux"
     sha256 = "cca35b096adc9e22b1ea39922165db94039fa2d064fe9ab0252af9481f37d296"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-linux-musl.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "981f51d3dce1dfddd165a8453443abfeee48e962"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "386d4334764f0941ab63434370a5845933e3144c28cdaff79add76d325708206"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "dd31b285186d4ef6917f52fa87b91e7f036359f0"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "e648f2069c48adf65d436b2f7f5427767a0098e6e28bd63772014a29aea4ba47"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "0017c72b4278ffc09a567f13efd22e1d9d4898e8"
@@ -2989,6 +3165,28 @@ os = "linux"
     [["RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "a23e1f638397434552be742082ae3f75b95d616d4a5679c6ff5be7b1d381d8b8"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-i686-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "0db4b2b650a7e058870a732fbd496cbf49aa9fec"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "37b56c30409028b12558d342ca8595ecd3b1549635d0adb76cbe706c18e7d1cc"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "78569cf68455e762e9ba485855ed29343dcab017"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "fa4261f70bc07e118ea398d6cb4c44a53d0ab8fa0a45f8cdf83caaac765bde16"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -3012,6 +3210,28 @@ os = "linux"
     sha256 = "eeac1c672ccab57e827d71bdb851f4a75cbfc8b0742c27b02f54a0cde6004463"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-powerpc64le-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "254e019df8279383de2c0b3073fb0f576d9d114e"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "6cd337bbaac37924760e04c1a50584360fa399d757b0e7a0caf84956b0e9dfd1"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "02921a8809a3bab701f83a194a6934d17a16d672"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "c6d31476c1adce971db2279413daca3d2eb85c7c4b415d8903bbc782db619ebc"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "4ed3e360244bab5c293fc5300c8c7ed4459f5522"
@@ -3033,6 +3253,28 @@ os = "linux"
     [["RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "57539536a01b5a95d8c092bfa3087dc7cdffcfbce3e291b4c387227bd134c0e5"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-apple-darwin.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "e3f99f63540a645d8a5fa1b8703a909ca8e2026b"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "6b49066c6fcf0feaa3e9dd9095af4b6e828b3c3167cd102cbaa204db05ae53bb"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "801839c4512d7346595d71e1387ef3a6b4331e48"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "e5878e6d73024be1002d5217091878ed0a8860a94a3f15dc6a601245237dfdf3"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -3056,6 +3298,28 @@ os = "linux"
     sha256 = "3693828b8f3fccbecaf213c4d8717a95a7329f1ce3ed644c4be5f0a472e77dc4"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-linux-gnu.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "dfb0cf007084f9b3217add146cfdc66a6c772164"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "7df4fc9910c01a9060f4a65994537403c94ab7e8aa251c76f77c399e74e6cda2"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "d0ce28e7dc5283f336079c31c799cd3a3ec5a276"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "1ece03664f540a428b66f08c04801f64200b52172302d6d0f6762899a47ae897"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "5e867eaf4198438e6e2b964a92a359a28438823f"
@@ -3077,6 +3341,28 @@ os = "linux"
     [["RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "fe5a583c78964ee49108a80e9d1f234540a92ddf3d8f1e540f32a6f5ebfd50a6"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-linux-musl.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "323e2240a1b3e0356e1e910c2c38feec683401e4"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "ebb4d9c718d4114e4d2264463b5dc9e50c622fcb53192824e273ea6e51e29f5f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "d46a809a8b93be19de76bd695d0367b1c2b4ef5c"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "f3e2abc52ee2825b17d5d8c1cd90b5e7054b86fed065fd612615cc131e3d71c5"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -3100,6 +3386,28 @@ os = "linux"
     sha256 = "8aacd26cf5e54418403779a1d4a7a9a19797ed90c3fe034015fc4443108fbb61"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-unknown-freebsd.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "01f03c83d75ac67819f5d963fc071bea2e2da899"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "f8014d0d4b5627451efbd137db8f0419d9aa4e8aab887d4399c7000e8a8e1478"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "287acc8cf73477e50855ff1a5848963b602308e6"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "2a8ebbe024a087b3629a5d26e39fb757b8acc45c57d92e86b7c1742ec37a6aa9"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "4f995d8f9a0d1f1631f93e138ed0009ded0a8c81"
@@ -3121,3 +3429,25 @@ os = "linux"
     [["RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "9302af586d24b8c60fe5268c2646c6ad4ac488458244219b8c5d7d3076701b89"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.43.0/RustToolchain-x86_64-w64-mingw32.v1.43.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "fc14f8f9e1aa0b153f5bc910a6aa79c657c0be8c"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "41394625261e6c2b211e3defb5a5d06e853db0e26abf1ad855f1db35b396cf00"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "2f8a594364af942ec4766133c89ddf606733fa2d"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "5e8e72c6b9c168abfbc4c96b08234cf35849a5048e17d69980cf0dc046028989"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2814,332 +2814,376 @@ os = "linux"
     sha256 = "aa5aef6b4c68b28c135da87d3d0169e142a84b89d556748f3f37d30355b9ca17"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2021.7.13/Rootfs.v2021.7.13.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustBase.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustBase.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "bc607dbb4a6b8032c5782dbc5116bbe2f5644add"
+git-tree-sha1 = "ced9ffc9b69fbf10db7f413aacfd4d6099825cf2"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustBase.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "de692f3cbc235701608300721db6c43c754936204b8b31f4f8709ff22618bbd8"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.56.1/RustBase.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustBase.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "9253a7c86abeed00b56fef13f38d9596e44d22c6627267e817c25b2c789d51eb"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.57.0/RustBase.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustBase.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustBase.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "e6b8dda037c6b3b747d71f1cde25cf79e2a271de"
+git-tree-sha1 = "c159858cd41953db633f4ed35ec784bf753ede05"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustBase.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "21b801b9f6acd7d3f5e334974d4165637e8eb8960cce6a99eccdf1d59edc3c28"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.56.1/RustBase.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustBase.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "48ba8bafea12c019c7a8b1ad860f24a41c49109e73418458af1c80ca859826c9"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.57.0/RustBase.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-aarch64-apple-darwin.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "6e4e76e922d1c685da8f0edc2d4615589544cf17"
+git-tree-sha1 = "f12052bec0cfb5df95d3c7dd7ae0be0594eed0fb"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "1ff64974af9194dd2bb3b752dfcd0caf30b49e957e1a03f7b8bb79309d44b92a"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-aarch64-apple-darwin.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "5eb43ce3b42a7371971aa1206589925ef80b0d8494ecf1dd6082ee537c09d36c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-aarch64-apple-darwin.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-aarch64-apple-darwin.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "5957e8124cd32bf834eb302d9e7d16c648afc8f2"
+git-tree-sha1 = "7a709b7514d01ae2b59db9a5b3d2d268c335a152"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "3f1947fd450d643c1c914da2293534b0bd45e5f4096983cc964f032efc065ac8"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-aarch64-apple-darwin.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "e5c57df9ec9ffa77ca63bdce137c45569d9a8021fb5b370991a8626e96caa9c6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-aarch64-apple-darwin.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-aarch64-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "05b87e9dbb0c783a41f432476d3661643b659edb"
+git-tree-sha1 = "10f73e278d07d66b87ac037832ca4da4c0daa3da"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "9bcd51d6d391988f9420659bbb87f467ebfa05d500f613f3cdbdff4e068c9f16"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-aarch64-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "d5e6104c41c37632620e041b765662e2b8ec0a52143f44d8e3211719723b8a1b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-aarch64-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-aarch64-linux-gnu.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "5f11ac937d6cf3a1f4a2a946fab72f5047d039f9"
+git-tree-sha1 = "daa038c5a5a2d49a185eafec42499e7eff1c0e1c"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "7d908d8bda29e04315568689f1ccd6e85405087669b94704231736ad0feedaa4"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-aarch64-linux-gnu.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "04dd4d99969201e6cd4a00529f4938c7b29f5fa838a85548f325a258df569035"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-aarch64-linux-gnu.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-aarch64-linux-musl.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "f34e54bae8a5d34d1c3e2532c313a59791fca71b"
+git-tree-sha1 = "810db8e4711de59c9bf7468377bc08dcb8a56a2b"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "cc0247a6d40b84486dfce80ec9acf1e30f5d35535007da7ffc916b40bbebab7d"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-aarch64-linux-musl.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "8bec5d1b6857d4a113dbcf938606ec9a61ba0f16c12ef45290e28cc4279a31d6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-aarch64-linux-musl.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-aarch64-linux-musl.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "0075024bd660067db98c6fc4e57660646e99597b"
+git-tree-sha1 = "1cdc30c0a24d4f307dec728b0e0f048e90260291"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "a7ea89ec1619a754f6e2573caba29f5fa5b65493c62320a41f431e3fd1d5600b"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-aarch64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-aarch64-linux-musl.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "77c592aef08aa84326ae53725d6faea50c8a8b088f90cb37bdfcb1caa2e7f7bb"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-aarch64-linux-musl.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-armv6l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "199b6e8f90be5f971d80ee6d5702a9b260e246fa"
+git-tree-sha1 = "413af8cad1f9a0904c0bf6d72f7d28248489e733"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "e402a018ef50085aa60792b26d7d8cc0a351bf8f33091b6f611129b7405aa116"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1+0/RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-armv6l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "a123cc0acb61d194ece58e45ed48d095629a30e2bf7497ad39a95a55809528f1"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-armv6l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-armv6l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "0d1abb3132be195e45db8eb2365c072f39bba538"
+git-tree-sha1 = "0e59715e3456003de7e320bd0f119a5adf3f66fb"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "ffd73b9a195ba5b2af4f9f9e3242523d2a7b8e0a9f0cb3b33081063c9c881bd9"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1+0/RustToolchain-armv7l-linux-gnueabihf.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-armv6l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "30f03d5317b3fd2dfd2cc245c29ef6c9d2280b4a5921d9c682e24e518acf2a51"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-armv6l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-armv6l-linux-musleabihf.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "d85715815f4a9dc202b75ba495d42b5aa22176f2"
+git-tree-sha1 = "5fe0c670498b95d38bd4c04e571e5d333c5600e0"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "00e4f4985afb7f268ba6f2de9375b73cc139046f2e5b72f4d0e3606ad943a252"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1+0/RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-armv6l-linux-musleabihf.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "a21cbca975c8ae306249b6c3a58cf62e89ac8f60a1726220b2014dcdc2492fc2"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-armv6l-linux-musleabihf.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-armv6l-linux-musleabihf.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "5b5aabb64a3d725e239cfdb1c32eef14d518a9ab"
+git-tree-sha1 = "2796a12be42c4ab1011b042a966fe23444a4305e"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "3b55cf03789c698a9e741535a962847f2efb43114e238336308213b475f62578"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1+0/RustToolchain-armv7l-linux-musleabihf.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-armv6l-linux-musleabihf.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "37e81676e8412d962ccccb105bfd0f89dbac16be6683ff7ea7479cb7d8230c60"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-armv6l-linux-musleabihf.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-armv7l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "6cef979bc23000a2879d60bf33b3a9fbc1d4c9f1"
+git-tree-sha1 = "682aaa203d1f7d0ea44b32b580a06be6cee53a5c"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "8e012d132ec4d65029903b30da97865da035bdd455d00895e52a1753e198eaef"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "b00f5b223571f5f7dabe8591c602c63d68bc771429adbf26a98504e2a0fca0eb"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-armv7l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-armv7l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "55bb1f1c59667f9e7d01567b03025d1b3aba74eb"
+git-tree-sha1 = "7d2bc38d1265a9b831e6361612f4599c47fe3eb5"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "b9cbde430b929a7defbc57b5197d282e527fbd4fdb3a4baa00fc31708da43c30"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "7527a21f6d827624ae725d6c48b9b5a9d3906baffc28b9178b65ef2e8b34584d"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-armv7l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-armv7l-linux-musleabihf.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "981f51d3dce1dfddd165a8453443abfeee48e962"
+git-tree-sha1 = "4cbc067a6fc0365568a5665d97f50759b5e5ce30"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "386d4334764f0941ab63434370a5845933e3144c28cdaff79add76d325708206"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-armv7l-linux-musleabihf.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "1efd6793726657f09fcc3807e84c9287eec37268046ba541ab9ed7ba6dc48645"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-armv7l-linux-musleabihf.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-armv7l-linux-musleabihf.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "dd31b285186d4ef6917f52fa87b91e7f036359f0"
+git-tree-sha1 = "b1231774e23490b45727c11053b1bc56e3ae16c9"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "e648f2069c48adf65d436b2f7f5427767a0098e6e28bd63772014a29aea4ba47"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-linux-musl.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-armv7l-linux-musleabihf.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "cc005f7614984be4e0d05ce4813a1357de69b3080f2a3bc91472a89510e20cf0"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-armv7l-linux-musleabihf.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-i686-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "0db4b2b650a7e058870a732fbd496cbf49aa9fec"
+git-tree-sha1 = "b64f5fddb28f7b1240591de34238fd8f55a14af0"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "37b56c30409028b12558d342ca8595ecd3b1549635d0adb76cbe706c18e7d1cc"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-i686-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "0bec79341069460ea08efaaa97cb442ec5ea271bd568e2fc933b623204b8d306"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-i686-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-i686-linux-gnu.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "78569cf68455e762e9ba485855ed29343dcab017"
+git-tree-sha1 = "5edb567b9261138868871f02ec1ab54658532016"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "fa4261f70bc07e118ea398d6cb4c44a53d0ab8fa0a45f8cdf83caaac765bde16"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-i686-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-i686-linux-gnu.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "2b7adcb6aa275dedd451f75253ebd84ff63db7cdd4079cf1634d5c11ec5120d5"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-i686-linux-gnu.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-i686-linux-musl.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "254e019df8279383de2c0b3073fb0f576d9d114e"
+git-tree-sha1 = "a744cffb841c02b6a8fc46d9a1e7990f27db62da"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "6cd337bbaac37924760e04c1a50584360fa399d757b0e7a0caf84956b0e9dfd1"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-i686-linux-musl.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "1b1b351286789ce92912eedc8963d9f515571ca71965cd697c76eea70af0dfec"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-i686-linux-musl.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-i686-linux-musl.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "02921a8809a3bab701f83a194a6934d17a16d672"
+git-tree-sha1 = "3951422e54fe165ad7decd4b76f27c4b552b5db4"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "c6d31476c1adce971db2279413daca3d2eb85c7c4b415d8903bbc782db619ebc"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-powerpc64le-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-i686-linux-musl.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "fd37997f452315fc71db0b7fd76158d3d084b08016d56c86f08fc10f5a2616de"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-i686-linux-musl.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-i686-w64-mingw32.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "e3f99f63540a645d8a5fa1b8703a909ca8e2026b"
+git-tree-sha1 = "9edbf2ea53630008e03cbaad59a13eb1f8b4a3ed"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "6b49066c6fcf0feaa3e9dd9095af4b6e828b3c3167cd102cbaa204db05ae53bb"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-i686-w64-mingw32.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "eb69dab9e416cf271ac76c63eae15a0e8f36b953783eb840f358e74fe9b7f736"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-i686-w64-mingw32.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-i686-w64-mingw32.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "801839c4512d7346595d71e1387ef3a6b4331e48"
+git-tree-sha1 = "e76225b0a9516778e35959f9d35d5b11c462d157"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "e5878e6d73024be1002d5217091878ed0a8860a94a3f15dc6a601245237dfdf3"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-apple-darwin.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-i686-w64-mingw32.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "a8e00d0df9558d8420a156ae23a5046b893c53c52c452c955ccab89c27da89b6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-i686-w64-mingw32.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-powerpc64le-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "dfb0cf007084f9b3217add146cfdc66a6c772164"
+git-tree-sha1 = "e4b8afc31d9d30ad7bce739724965a96a580c023"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "7df4fc9910c01a9060f4a65994537403c94ab7e8aa251c76f77c399e74e6cda2"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-powerpc64le-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "2d8644a92c2afa96233147db01600d68685c7072d4f4cc9db55f6124caca9625"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-powerpc64le-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-powerpc64le-linux-gnu.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "d0ce28e7dc5283f336079c31c799cd3a3ec5a276"
+git-tree-sha1 = "17a02c9fd678db47bfa011457d37ecc5cd2e6e76"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "1ece03664f540a428b66f08c04801f64200b52172302d6d0f6762899a47ae897"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-linux-gnu.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-powerpc64le-linux-gnu.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "c466d681ca729f97c35e2f197c921b659ffc806ed6fc192bf336576fab83a5f4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-powerpc64le-linux-gnu.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-x86_64-apple-darwin.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "323e2240a1b3e0356e1e910c2c38feec683401e4"
+git-tree-sha1 = "01438a29ebc999deea2a2903e266b1bd7d0a210f"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "ebb4d9c718d4114e4d2264463b5dc9e50c622fcb53192824e273ea6e51e29f5f"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-x86_64-apple-darwin.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "c005da7c5937e9805f21bcfa42474b0257987f8134518884abff0de8c287210a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-x86_64-apple-darwin.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-x86_64-apple-darwin.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "d46a809a8b93be19de76bd695d0367b1c2b4ef5c"
+git-tree-sha1 = "8dbdb718d9e2e5bc73d4e1d0368f7ee084758042"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "f3e2abc52ee2825b17d5d8c1cd90b5e7054b86fed065fd612615cc131e3d71c5"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-linux-musl.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-x86_64-apple-darwin.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "0f08b16b55bbfeffecab2ed0d209c060e5464d425a84d842b1028baf753eecbd"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-x86_64-apple-darwin.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-x86_64-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "01f03c83d75ac67819f5d963fc071bea2e2da899"
+git-tree-sha1 = "7c8a89e82ffdec87a9deb47375eea4b25953bc5b"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "f8014d0d4b5627451efbd137db8f0419d9aa4e8aab887d4399c7000e8a8e1478"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-x86_64-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "8de2cf7e205ddc47a5a1883f94a91c9eac5422f68ae54a379815634245868250"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-x86_64-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-x86_64-linux-gnu.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "287acc8cf73477e50855ff1a5848963b602308e6"
+git-tree-sha1 = "696469130062fcbf9e0b3811bc8eec57cccf089b"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "2a8ebbe024a087b3629a5d26e39fb757b8acc45c57d92e86b7c1742ec37a6aa9"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-unknown-freebsd.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-x86_64-linux-gnu.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "de55dd925e283fd3541b6c1746ad363ec85ff46c2fdd83f03ac3ccb5ab34b734"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-x86_64-linux-gnu.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs"]]
+[["RustToolchain-x86_64-linux-musl.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "fc14f8f9e1aa0b153f5bc910a6aa79c657c0be8c"
+git-tree-sha1 = "f967da2f8d0138d69bc726d3ee9aefa812c4baec"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs".download]]
-    sha256 = "41394625261e6c2b211e3defb5a5d06e853db0e26abf1ad855f1db35b396cf00"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.squashfs.tar.gz"
+    [["RustToolchain-x86_64-linux-musl.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "104c2789562da5cfffe2c81d7a2983b4833f530915e9303761489d8e9e85004f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-x86_64-linux-musl.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
 
-[["RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked"]]
+[["RustToolchain-x86_64-linux-musl.v1.57.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "2f8a594364af942ec4766133c89ddf606733fa2d"
+git-tree-sha1 = "130ca235cf8d54a030244d8e4eaf4fb2a324fef6"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked".download]]
-    sha256 = "5e8e72c6b9c168abfbc4c96b08234cf35849a5048e17d69980cf0dc046028989"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.56.1/RustToolchain-x86_64-w64-mingw32.v1.56.1.x86_64-linux-musl.unpacked.tar.gz"
+    [["RustToolchain-x86_64-linux-musl.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "ddc81ef90ced7a8f451aa2136d2fbb1210db5a8de875fc374b25706e72f4ab22"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-x86_64-linux-musl.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-unknown-freebsd.v1.57.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "335de81ab0928b89bd4ef3d1db7a40925e5d9fe9"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-unknown-freebsd.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "82d4ae484dea61c5f0519c2e1c84d25314d08f046661193d96ad9e45d7e1438c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-x86_64-unknown-freebsd.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-unknown-freebsd.v1.57.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "03587cbc60a7933ef6ed7e05c32cc02c668064d3"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-unknown-freebsd.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "78e23b98ab3f00147078fd9d13f2b920b4bd77c96c8b65b584c7910c435fc5c3"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-x86_64-unknown-freebsd.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-w64-mingw32.v1.57.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "2b17ca3fd848ee5460e5a18a589416edcf002cd2"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-w64-mingw32.v1.57.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "3c69852a206f4a7af700f357123d4e4eb67c8c70ea45b39d4ceb2f16f61436f0"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-x86_64-w64-mingw32.v1.57.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-w64-mingw32.v1.57.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "a1a8590b9fc606eef1dfc55562864c68cc773912"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-w64-mingw32.v1.57.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "b99f996282765580f5598d7c2d5ab35666404bf6d929dbbde5ba054f13386720"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.57.0/RustToolchain-x86_64-w64-mingw32.v1.57.0.x86_64-linux-musl.unpacked.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.0.5"
+version = "1.1.0"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/BuildToolchains.jl
+++ b/src/BuildToolchains.jl
@@ -261,7 +261,7 @@ function cargo_config_file!(dir::AbstractString)
         write(io, """
         # Configuration file for `cargo`
         """)
-        for platform in supported_platforms()
+        for platform in supported_platforms(; experimental=true)
             # Use `aatriplet` for the linker to match how the wrappers are
             # written in
             # https://github.com/JuliaPackaging/BinaryBuilderBase.jl/blob/30d056ef68f81dca9cb91ededcce6b68c6466b37/src/Runner.jl#L599.
@@ -269,13 +269,6 @@ function cargo_config_file!(dir::AbstractString)
             [target.$(map_rust_target(platform))]
             linker = "$(aatriplet(platform))-gcc"
             """)
-            if platforms_match(platform, Platform("aarch64", "linux"; libc="musl"))
-                # Work around bug for this platform:
-                # https://github.com/rust-lang/rust/issues/46651#issuecomment-433611633
-                write(io, """
-                rustflags = ["-C", "link-arg=-lgcc"]
-                """)
-            end
         end
     end
 end

--- a/src/DockerRunner.jl
+++ b/src/DockerRunner.jl
@@ -94,8 +94,18 @@ function DockerRunner(workspace_root::String;
 
     if isempty(bootstrap_list)
         # Generate CMake and Meson files, only if we are not bootstrapping
-        generate_toolchain_files!(platform, envs; toolchains_path=toolchains_path)
+        generate_toolchain_files!(platform, envs, toolchains_path)
         push!(workspaces, toolchains_path => "/opt/toolchains")
+    end
+
+    # Generate directory where to write Cargo config files
+    compilers = collect(extract_kwargs(kwargs, (:compilers,)))
+    if isone(length(compilers)) && :rust in compilers[1].second
+        cargo_dir = mktempdir()
+        cargo_config_file!(cargo_dir)
+        # Add to the list of mappings a subdirectory of ${CARGO_HOME}, whose content
+        # will be put in ${CARGO_HOME}.
+        push!(workspaces, cargo_dir => envs["CARGO_HOME"] * "/" * randstring())
     end
 
     # the workspace_root is always a workspace, and we always mount it first

--- a/src/DockerRunner.jl
+++ b/src/DockerRunner.jl
@@ -99,15 +99,15 @@ function DockerRunner(workspace_root::String;
         # Generate CMake and Meson files, only if we are not bootstrapping
         generate_toolchain_files!(platform, envs, toolchains_path)
         push!(workspaces, toolchains_path => "/opt/toolchains")
-    end
 
-    # Generate directory where to write Cargo config files
-    if isone(length(collect(compilers))) && :rust in collect(compilers)[1].second
-        cargo_dir = mktempdir()
-        cargo_config_file!(cargo_dir)
-        # Add to the list of mappings a subdirectory of ${CARGO_HOME}, whose content
-        # will be put in ${CARGO_HOME}.
-        push!(workspaces, cargo_dir => envs["CARGO_HOME"] * "/" * randstring())
+        # Generate directory where to write Cargo config files
+        if isone(length(collect(compilers))) && :rust in collect(compilers)[1].second
+            cargo_dir = mktempdir()
+            cargo_config_file!(cargo_dir)
+            # Add to the list of mappings a subdirectory of ${CARGO_HOME}, whose content
+            # will be put in ${CARGO_HOME}.
+            push!(workspaces, cargo_dir => envs["CARGO_HOME"] * "/" * randstring())
+        end
     end
 
     # the workspace_root is always a workspace, and we always mount it first

--- a/src/DockerRunner.jl
+++ b/src/DockerRunner.jl
@@ -84,12 +84,15 @@ function DockerRunner(workspace_root::String;
     # encrypted directory, as that can trigger kernel bugs
     check_encryption(workspace_root; verbose=verbose)
 
+    # Extract compilers argument
+    compilers = collect(extract_kwargs(kwargs, (:compilers,)))
+
     # Construct environment variables we'll use from here on out
-    platform = get_concrete_platform(platform; extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:compilers))...)
-    envs = merge(platform_envs(platform, src_name; verbose=verbose), extra_env)
+    platform = get_concrete_platform(platform; compilers..., extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version))...)
+    envs = merge(platform_envs(platform, src_name; verbose, compilers...), extra_env)
 
     # JIT out some compiler wrappers, add it to our mounts
-    generate_compiler_wrappers!(platform; bin_path=compiler_wrapper_path, extract_kwargs(kwargs, (:compilers,:allow_unsafe_flags,:lock_microarchitecture))...)
+    generate_compiler_wrappers!(platform; bin_path=compiler_wrapper_path, compilers..., extract_kwargs(kwargs, (:allow_unsafe_flags,:lock_microarchitecture))...)
     push!(workspaces, compiler_wrapper_path => "/opt/bin")
 
     if isempty(bootstrap_list)
@@ -99,8 +102,7 @@ function DockerRunner(workspace_root::String;
     end
 
     # Generate directory where to write Cargo config files
-    compilers = collect(extract_kwargs(kwargs, (:compilers,)))
-    if isone(length(compilers)) && :rust in compilers[1].second
+    if isone(length(collect(compilers))) && :rust in collect(compilers)[1].second
         cargo_dir = mktempdir()
         cargo_config_file!(cargo_dir)
         # Add to the list of mappings a subdirectory of ${CARGO_HOME}, whose content
@@ -121,7 +123,7 @@ function DockerRunner(workspace_root::String;
 
     if isnothing(shards)
         # Choose the shards we're going to mount
-        shards = choose_shards(platform; extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:bootstrap_list,:compilers))...)
+        shards = choose_shards(platform; compilers..., extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:bootstrap_list))...)
     end
 
     # Import docker image

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -512,7 +512,7 @@ function choose_shards(p::AbstractPlatform;
             ps_build::VersionNumber=v"2021.08.10",
             GCC_builds::Vector{GCCBuild}=available_gcc_builds,
             LLVM_builds::Vector{LLVMBuild}=available_llvm_builds,
-            Rust_build::VersionNumber=v"1.43.0",
+            Rust_build::VersionNumber=v"1.56.1",
             Go_build::VersionNumber=v"1.16.3",
             archive_type::Symbol = (use_squashfs ? :squashfs : :unpacked),
             bootstrap_list::Vector{Symbol} = bootstrap_list,

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -514,7 +514,7 @@ function choose_shards(p::AbstractPlatform;
             ps_build::VersionNumber=v"2021.08.10",
             GCC_builds::Vector{GCCBuild}=available_gcc_builds,
             LLVM_builds::Vector{LLVMBuild}=available_llvm_builds,
-            Rust_build::VersionNumber=v"1.56.1",
+            Rust_build::VersionNumber=v"1.57.0",
             Go_build::VersionNumber=v"1.16.3",
             archive_type::Symbol = (use_squashfs ? :squashfs : :unpacked),
             bootstrap_list::Vector{Symbol} = bootstrap_list,

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -397,14 +397,17 @@ const available_llvm_builds = [
 ]
 
 """
-    gcc_version(p::AbstractPlatform, , GCC_builds::Vector{GCCBuild};
+    gcc_version(p::AbstractPlatform, GCC_builds::Vector{GCCBuild},
+                compilers::Vector{Symbol}=[:c];
                 llvm_version::Union{Nothing,VersionNumber}=nothing)
 
 Returns the closest matching GCC version number for the given particular
 platform, from the given set of options.  The compiler ABI and the
 microarchitecture of the platform will be taken into account.  If no match is
-found, returns an empty list.  If the keyword argument `llvm_version` is passed,
-it is used to filter the version of GCC for FreeBSD platforms.
+found, returns an empty list.  `compilers` is the list of compilers used in the
+build, to choose the right version of GCC to couple with them if necessary.  If
+the keyword argument `llvm_version` is passed, it is used to filter the version
+of GCC for FreeBSD platforms.
 
 This method assumes that the compiler ABI of the platform represents a platform
 that binaries will be run on, and thus versions are always rounded down; e.g. if
@@ -413,7 +416,8 @@ the only GCC versions available to be picked from are `4.8.5` and `5.2.0`, it
 will return `4.8.5`, as binaries compiled with that version will run on this
 platform, whereas binaries compiled with `5.2.0` may not.
 """
-function gcc_version(p::AbstractPlatform, GCC_builds::Vector{GCCBuild};
+function gcc_version(p::AbstractPlatform,GCC_builds::Vector{GCCBuild},
+                     compilers::Vector{Symbol}=[:c];
                      llvm_version::Union{Nothing,VersionNumber}=nothing)
     # First, filter by libgfortran version.
     if libgfortran_version(p) !== nothing
@@ -447,6 +451,12 @@ function gcc_version(p::AbstractPlatform, GCC_builds::Vector{GCCBuild};
         GCC_builds = filter(b -> getversion(b) ≥ v"6", GCC_builds)
     end
 
+    # Rust on Windows requires binutils 2.25 (it invokes `ld` with `--high-entropy-va`),
+    # which we bundle with GCC 5.
+    if :rust in compilers && Sys.iswindows(p)
+        GCC_builds = filter(b -> getversion(b) ≥ v"5", GCC_builds)
+    end
+
     # Filter the possible GCC versions depending on the microarchitecture
     if march(p) in ("avx", "avx2", "neonvfpv4")
         # "sandybridge", "haswell", "cortex-a53" introduced in GCC v4.9.0:
@@ -477,6 +487,7 @@ function llvm_version(p::AbstractPlatform, LLVM_builds::Vector{LLVMBuild})
 end
 
 function select_compiler_versions(p::AbstractPlatform,
+            compilers::Vector{Symbol},
             GCC_builds::Vector{GCCBuild} = available_gcc_builds,
             LLVM_builds::Vector{LLVMBuild} = available_llvm_builds,
             preferred_gcc_version::VersionNumber = getversion(GCC_builds[1]),
@@ -490,7 +501,7 @@ function select_compiler_versions(p::AbstractPlatform,
     end
     llvmv = select_closest_version(preferred_llvm_version, filtered_llvm_builds)
 
-    filtered_gcc_builds = gcc_version(p, GCC_builds; llvm_version=llvmv)
+    filtered_gcc_builds = gcc_version(p, GCC_builds, compilers; llvm_version=llvmv)
     if isempty(filtered_gcc_builds)
         error("Impossible compiler constraints $(p) upon $(GCC_builds)!")
     end
@@ -569,6 +580,7 @@ function choose_shards(p::AbstractPlatform;
     if isempty(bootstrap_list)
         # Select GCC and LLVM versions given the compiler ABI and target requirements given in `p`
         GCC_build, LLVM_build = select_compiler_versions(p,
+            compilers,
             this_platform_GCC_builds,
             LLVM_builds,
             preferred_gcc_version,

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -67,8 +67,10 @@ function artifact_name(cs::CompilerShard)
     if cs.target != nothing
         target_str = "-$(triplet(cs.target))"
 
-        # armv6l uses the same shards as armv7l, so we just rename here.
-        target_str = replace(target_str, "-armv6l-linux" => "-armv7l-linux")
+        if cs.name == "GCCBootstrap"
+            # armv6l uses the same GCC shards as armv7l, so we just rename here.
+            target_str = replace(target_str, "-armv6l-linux" => "-armv7l-linux")
+        end
     end
     ext = Dict(:squashfs => "squashfs", :unpacked => "unpacked")[cs.archive_type]
     return "$(cs.name)$(target_str).v$(cs.version).$(triplet(cs.host)).$(ext)"

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -372,7 +372,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     function macos_gcc_flags!(p::AbstractPlatform, flags::Vector{String} = String[])
         # On macOS, if we're on an old GCC, the default -syslibroot that gets
         # passed to the linker isn't calculated correctly, so we have to manually set it.
-        gcc_version, llvm_version = select_compiler_versions(p)
+        gcc_version, llvm_version = select_compiler_versions(p, compilers)
         if gcc_version.major in (4, 5)
             push!(flags, "-Wl,-syslibroot,/opt/$(aatriplet(p))/$(aatriplet(p))/sys-root")
         end
@@ -423,7 +423,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     function gcc_link_flags!(p::AbstractPlatform, flags::Vector{String} = String[])
         # Yes, it does seem that the inclusion of `/lib64` on `powerpc64le` was fixed
         # in GCC 6, broken again in GCC 7, and then fixed again for GCC 8 and 9
-        gcc_version, llvm_version = select_compiler_versions(p)
+        gcc_version, llvm_version = select_compiler_versions(p, compilers)
         if arch(p) == "powerpc64le" && Sys.islinux(p) && gcc_version.major in (4, 5, 7)
             append!(flags, String[
                 "-L/opt/$(aatriplet(p))/$(aatriplet(p))/sys-root/lib64",

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -817,8 +817,10 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     end
 end
 
-# Translation mappers for our target names to cargo-compatible ones
-map_rust_arch(p::AbstractPlatform) = replace(arch(p), "armv7l" => "armv7")
+# Translation mappers for our target names to cargo-compatible ones.  See
+# https://doc.rust-lang.org/rustc/platform-support.html
+map_rust_arch(p::AbstractPlatform) =
+    replace(replace(arch(p), "armv7l" => "armv7"), "armv6l" => "arm")
 function map_rust_target(p::AbstractPlatform)
     if Sys.isapple(p)
         return "$(map_rust_arch(p))-apple-darwin"

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -986,7 +986,7 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
             "CARGO_HOME" => "/opt/$(host_target)",
             "RUSTUP_HOME" => "/opt/$(host_target)",
             # TODO: we'll need a way to parameterize this toolchain number
-            "RUSTUP_TOOLCHAIN" => "1.56.1-$(map_rust_target(host_platform))",
+            "RUSTUP_TOOLCHAIN" => "1.57.0-$(map_rust_target(host_platform))",
         ))
     end
 

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -988,7 +988,7 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
         "CARGO_HOME" => "/opt/$(host_target)",
         "RUSTUP_HOME" => "/opt/$(host_target)",
         # TODO: we'll need a way to parameterize this toolchain number
-        "RUSTUP_TOOLCHAIN" => "1.43.0-$(map_rust_target(host_platform))",
+        "RUSTUP_TOOLCHAIN" => "1.56.1-$(map_rust_target(host_platform))",
 
         # We conditionally add on some compiler flags; we'll cull empty ones at the end
         "USE_CCACHE" => "$(use_ccache)",

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -49,8 +49,18 @@ function UserNSRunner(workspace_root::String;
 
     if isempty(bootstrap_list)
         # Generate CMake and Meson files, only if we are not bootstrapping
-        generate_toolchain_files!(platform, envs; toolchains_path=toolchains_path)
+        generate_toolchain_files!(platform, envs, toolchains_path)
         push!(workspaces, toolchains_path => "/opt/toolchains")
+    end
+
+    # Generate directory where to write Cargo config files
+    compilers = collect(extract_kwargs(kwargs, (:compilers,)))
+    if isone(length(compilers)) && :rust in compilers[1].second
+        cargo_dir = mktempdir()
+        cargo_config_file!(cargo_dir)
+        # Add to the list of mappings a subdirectory of ${CARGO_HOME}, whose content
+        # will be put in ${CARGO_HOME}.
+        push!(mappings, cargo_dir => envs["CARGO_HOME"] * "/" * randstring())
     end
 
     # the workspace_root is always a workspace, and we always mount it first

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -54,15 +54,15 @@ function UserNSRunner(workspace_root::String;
         # Generate CMake and Meson files, only if we are not bootstrapping
         generate_toolchain_files!(platform, envs, toolchains_path)
         push!(workspaces, toolchains_path => "/opt/toolchains")
-    end
 
-    # Generate directory where to write Cargo config files
-    if isone(length(collect(compilers))) && :rust in collect(compilers)[1].second
-        cargo_dir = mktempdir()
-        cargo_config_file!(cargo_dir)
-        # Add to the list of mappings a subdirectory of ${CARGO_HOME}, whose content
-        # will be put in ${CARGO_HOME}.
-        push!(mappings, cargo_dir => envs["CARGO_HOME"] * "/" * randstring())
+        # Generate directory where to write Cargo config files
+        if isone(length(collect(compilers))) && :rust in collect(compilers)[1].second
+            cargo_dir = mktempdir()
+            cargo_config_file!(cargo_dir)
+            # Add to the list of mappings a subdirectory of ${CARGO_HOME}, whose content
+            # will be put in ${CARGO_HOME}.
+            push!(mappings, cargo_dir => envs["CARGO_HOME"] * "/" * randstring())
+        end
     end
 
     # the workspace_root is always a workspace, and we always mount it first

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -149,6 +149,12 @@ end
 
         p = Platform("armv7l", "linux"; march="neonvfpv4")
         @test gcc_version(p, available_gcc_builds) == [v"5.2.0", v"6.1.0", v"7.1.0", v"8.1.0", v"9.1.0", v"10.2.0", v"11.1.0", v"11.0.0-iains"]
+
+        # When Rust is used on x86_64 Windows, we have to use at least binutils
+        # 2.25, which we bundle with at least GCC 5.
+        p = Platform("x86_64", "windows"; libgfortran_version=v"3")
+        @test gcc_version(p, available_gcc_builds, [:c, :go]) == [v"4.8.5", v"5.2.0", v"6.1.0"]
+        @test gcc_version(p, available_gcc_builds, [:c, :rust]) == [v"5.2.0", v"6.1.0"]
     end
 
     @testset "Compiler wrappers" begin


### PR DESCRIPTION
This will replace the file we currently hard-code in the Rust compiler shard.

PR to update Rust toolchain build script: https://github.com/JuliaPackaging/Yggdrasil/pull/3992