### PR TITLE
[Rootfs] Fix name of PlatformSupport artifacts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -67,7 +67,7 @@ function artifact_name(cs::CompilerShard)
     if cs.target != nothing
         target_str = "-$(triplet(cs.target))"
 
-        if cs.name == "GCCBootstrap"
+        if cs.name in ("GCCBootstrap", "PlatformSupport")
             # armv6l uses the same GCC shards as armv7l, so we just rename here.
             target_str = replace(target_str, "-armv6l-linux" => "-armv7l-linux")
         end


### PR DESCRIPTION
Also `PlatformSupport` calls the armv6l artifacts `armv7l`