### PR TITLE
[BuildToolchains] Use `<aatriplet>-cc` as linker in Cargo config

### DIFF
--- a/src/DockerRunner.jl
+++ b/src/DockerRunner.jl
@@ -103,7 +103,7 @@ function DockerRunner(workspace_root::String;
         # Generate directory where to write Cargo config files
         if isone(length(collect(compilers))) && :rust in collect(compilers)[1].second
             cargo_dir = mktempdir()
-            cargo_config_file!(cargo_dir)
+            cargo_config_file!(cargo_dir, platform)
             # Add to the list of mappings a subdirectory of ${CARGO_HOME}, whose content
             # will be put in ${CARGO_HOME}.
             push!(workspaces, cargo_dir => envs["CARGO_HOME"] * "/" * randstring())

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -765,22 +765,6 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             write_wrapper(rustc, p, "$(t)-rustc")
             write_wrapper(rustup, p, "$(t)-rustup")
             write_wrapper(cargo, p, "$(t)-cargo")
-
-            # For FreeBSD and macOS we need to create an unversioned link for
-            # gcc because that's the linker our Rust toolchain expects:
-            # https://github.com/JuliaPackaging/Yggdrasil/blob/fff0583bc2d8f32e450c427684f295524f38535d/0_RootFS/Rust/build_tarballs.jl#L115-L126.
-            if Sys.isbsd(p) && os_version(p) !== nothing
-                tmp_p = deepcopy(p)
-                delete!(tags(tmp_p), "os_version")
-                symlink("$(t)-gcc", joinpath(bin_path, triplet(p), "$(aatriplet(tmp_p))-gcc"))
-            end
-            # Currently our Rust toolchain expects the linker for armv7l and
-            # armv6l with the platform "*l" suffix in the platform.  Until
-            # https://github.com/JuliaPackaging/Yggdrasil/pull/2168 makes it to
-            # the Rust toolchain, we create a symlink to work around this issue.
-            if proc_family(p) == "arm" && nbits(p) == 32
-                symlink("$(t)-gcc", joinpath(bin_path, triplet(p), "$(triplet(abi_agnostic(p)))-gcc"))
-            end
         end
     end
 

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -58,7 +58,7 @@ function UserNSRunner(workspace_root::String;
         # Generate directory where to write Cargo config files
         if isone(length(collect(compilers))) && :rust in collect(compilers)[1].second
             cargo_dir = mktempdir()
-            cargo_config_file!(cargo_dir)
+            cargo_config_file!(cargo_dir, platform)
             # Add to the list of mappings a subdirectory of ${CARGO_HOME}, whose content
             # will be put in ${CARGO_HOME}.
             push!(mappings, cargo_dir => envs["CARGO_HOME"] * "/" * randstring())


### PR DESCRIPTION
I don't understand why we were forcing `gcc`, on `aarch64-apple-darwin` this
causes lots of trouble, because Cargo would pass in the argument `-arch arm64`
which isn't accepted by GCC, but it is by LLVM.

Now that we can JIT-generate the file, write the config only for host and target
platforms, we don't have the toolchains for the other platforms anyway.

Additionally, remove some workarounds previously added in `Runner.jl` to fix
errors in the old static config file.