### PR TITLE
[Runner] Add hot-fix to symlink `libc.musl-<ARCH>.so.1` -> `libc.so`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"


### PR DESCRIPTION
Address #188 before rebuilding all the GCC compiler shards for Musl.

With this PR:
```console
% julia-16 -e 'using BinaryBuilderBase; BinaryBuilderBase.runshell(Platform("aarch64", "linux"; libc="musl"))'
sandbox:${WORKSPACE} # ls -l /opt/${target}/${target}/sys-root/usr/lib/
total 15361
-r--r--r--    1 root     root          5320 Oct 21  2020 Scrt1.o
-r--r--r--    1 root     root          5120 Oct 21  2020 crt1.o
-r--r--r--    1 root     root          1072 Oct 21  2020 crti.o
-r--r--r--    1 root     root          1012 Oct 21  2020 crtn.o
-r--r--r--    1 root     root      11614452 Oct 21  2020 libc.a
lrwxrwxrwx    1 root     root             7 Dec  5 14:19 libc.musl-aarch64.so.1 -> libc.so
-r-xr-xr-x    1 root     root       4082299 Oct 21  2020 libc.so
-r--r--r--    1 root     root             8 Oct 21  2020 libcrypt.a
-r--r--r--    1 root     root             8 Oct 21  2020 libdl.a
-r--r--r--    1 root     root             8 Oct 21  2020 libm.a
-r--r--r--    1 root     root             8 Oct 21  2020 libpthread.a
-r--r--r--    1 root     root             8 Oct 21  2020 libresolv.a
-r--r--r--    1 root     root             8 Oct 21  2020 librt.a
-r--r--r--    1 root     root             8 Oct 21  2020 libutil.a
-r--r--r--    1 root     root             8 Oct 21  2020 libxnet.a
-r--r--r--    1 root     root         14032 Oct 21  2020 rcrt1.o
```

~Note: this PR is built on top of #191, it's easier to read the second commit only.~ Edit: rebased on `master` now that #191 has been merged