### PR TITLE
[Runner] Set `-mmacosx-version-min` based on the actual macOS version

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -294,6 +294,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     end
 
     function macos_version(kernel_version::Integer)
+        # See https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history
         kernel_to_macos = Dict(
             12 => "10.8",
             13 => "10.9",
@@ -304,6 +305,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             18 => "10.14",
             19 => "10.15",
             20 => "11.0",
+            21 => "12.0",
         )
         return get(kernel_to_macos, kernel_version, nothing)
     end
@@ -318,7 +320,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
 
         # Eventually, we'll take this in `os_version(p)`, but not just yet.  We need to fix the paths
         # to the compiler shards first, since right now they have `14` at the end
-        version = v"14.0.0"
+        version = something(os_version(p), v"14.0.0")
         return macos_version(version.major)
     end
 
@@ -389,8 +391,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         end
 
         # Simulate some of the `__OSX_AVAILABLE()` macro usage that is broken in GCC
-        # Currently, we only target 10.10, but eventually, we'll want to tailor this to `os_version(p)`
-        if Sys.isapple(p) && 14 < 16
+        if Sys.isapple(p) && something(os_version(p), v"14") < v"16"
             # Disable usage of `clock_gettime()`
             push!(flags, "-D_DARWIN_FEATURE_CLOCK_GETTIME=0")
         end


### PR DESCRIPTION
With this I get:
```console
% julia-16 -e 'using BinaryBuilderBase; BinaryBuilderBase.runshell(Platform("aarch64", "macos"))'
sandbox:${WORKSPACE} # export SUPER_VERBOSE=1
sandbox:${WORKSPACE} # cc --version
ccache /opt/x86_64-linux-musl/bin/clang -target arm64-apple-darwin20 --sysroot=/opt/aarch64-apple-darwin20/aarch64-apple-darwin20/sys-root -march=armv8-a -mtune=cortex-a57 -nostdinc++ -isystem /opt/aarch64-apple-darwin20/aarch64-apple-darwin20/sys-root/usr/include/c++/v1 -Wno-unused-command-line-argument -mmacosx-version-min=11.0 --version -L/opt/aarch64-apple-darwin20/aarch64-apple-darwin20/lib -fuse-ld=aarch64-apple-darwin20 -headerpad_max_install_names
clang version 12.0.0 (/home/mose/.julia/dev/BinaryBuilderBase/deps/downloads/llvm-project.git d28af7c654d8db0b68c175db5ce212d74fb5e9bc)
Target: arm64-apple-darwin20
Thread model: posix
InstalledDir: /opt/x86_64-linux-musl/bin
```
Note `-mmacosx-version-min=11.0` instead of `-mmacosx-version-min=10.10`.