### PR TITLE
simplify `run_interactive`, `pipeline` can now accept an `IOBuffer`

### DIFF
--- a/src/DockerRunner.jl
+++ b/src/DockerRunner.jl
@@ -212,21 +212,7 @@ function run_interactive(dr::DockerRunner, cmd::Cmd; stdin = nothing, stdout = n
 
     try
         mount_shards(dr; verbose=verbose)
-        if stdout isa IOBuffer
-            if !(stdin isa IOBuffer)
-                stdin = devnull
-            end
-            process = open(docker_cmd, "r", stdin)
-            @async begin
-                while !eof(process)
-                    write(stdout, read(process))
-                end
-            end
-            wait(process)
-            return success(process)
-        else
-            return success(run(docker_cmd))
-        end
+        return success(run(docker_cmd))
     finally
         unmount_shards(dr; verbose=verbose)
         # Cleanup permissions, if we need to.

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -62,7 +62,7 @@ function UserNSRunner(workspace_root::String;
         sandbox_cmd = `$sandbox_cmd --verbose`
     end
     sandbox_cmd = `$sandbox_cmd --rootfs $(mpath)`
-    if cwd != nothing
+    if cwd !== nothing
         sandbox_cmd = `$sandbox_cmd --cd $cwd`
     end
 
@@ -204,21 +204,7 @@ function run_interactive(ur::UserNSRunner, user_cmd::Cmd; stdin = nothing, stdou
 
     try
         mount_shards(ur; verbose=verbose)
-        if stdout isa IOBuffer
-            if !(stdin isa IOBuffer)
-                stdin = devnull
-            end
-            process = open(cmd, "r", stdin)
-            @async begin
-                while !eof(process)
-                    write(stdout, read(process))
-                end
-            end
-            wait(process)
-            return success(process)
-        else
-            return success(run(cmd))
-        end
+        return success(run(cmd))
     finally
         unmount_shards(ur)
     end


### PR DESCRIPTION
```jl
julia> io = IOBuffer();

julia> run(pipeline(`echo hello`; stdout=io))
Process(`echo hello`, ProcessExited(0))

julia> String(take!(io))
"hello\n"
```