### PR TITLE
[Prefix] Remove unused `global_prefix` variable

### DIFF
--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -45,9 +45,6 @@ function temp_prefix(func::Function)
     end
 end
 
-# This is the default prefix that things get saved to, it is initialized within
-# __init__() on first module load.
-global_prefix = nothing
 struct Prefix
     path::String
 


### PR DESCRIPTION
Probably a cruft from `BinaryProvider` times: https://github.com/JuliaPackaging/BinaryProvider.jl/blob/55aeaea2652c1b43ba882c2f833196e99f10e2db/src/Prefix.jl#L64-L66