### PR TITLE
Improve relocatability of sysimages with BBBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/BinaryBuilderBase.jl
+++ b/src/BinaryBuilderBase.jl
@@ -74,7 +74,7 @@ const _artifacts_toml = @path Pkg.Artifacts.find_artifacts_toml(@__FILE__)
 
 function get_bbb_version(dir=@__DIR__, uuid="7f725544-6523-48cd-82d1-3fa08ff4056e")
     # Get BinaryBuilder.jl's version and git sha
-    version = Pkg.activate() do
+    version = Pkg.activate(".") do
         Pkg.Types.EnvCache().project.version
     end
     try
@@ -176,7 +176,7 @@ function __init__()
 
     deps_path = joinpath(@__DIR__, "..", "deps")
     ispath(deps_path) || begin
-        deps_path = joinpath(Pkg.depots1(), "dev", "BinaryBuilderBase.jl", "deps")
+        deps_path = joinpath(Pkg.depots1(), "binary_builder_deps")
         @info "Creating a storage cache at $deps_path"
     end
     # Allow the user to override the default value for `storage_dir`

--- a/src/BinaryBuilderBase.jl
+++ b/src/BinaryBuilderBase.jl
@@ -176,7 +176,7 @@ function __init__()
 
     deps_path = joinpath(@__DIR__, "..", "deps")
     ispath(deps_path) || begin
-        deps_path = joinpath(Base.DEPOT_PATH, "BinaryBuilderBase.jl", "deps")
+        deps_path = joinpath(Pkg.depots1(), "dev", "BinaryBuilderBase.jl", "deps")
         @info "Creating a storage cache at $deps_path"
     end
     # Allow the user to override the default value for `storage_dir`

--- a/src/BinaryBuilderBase.jl
+++ b/src/BinaryBuilderBase.jl
@@ -3,7 +3,7 @@ module BinaryBuilderBase
 using Pkg, Pkg.Artifacts, Random, Libdl, InteractiveUtils
 using Base.BinaryPlatforms
 using Downloads
-using JSON, OutputCollectors, Scratch
+using JSON, OutputCollectors, Scratch, RelocatableFolders
 
 # Re-export useful stuff from Base.BinaryPlatforms:
 export HostPlatform, platform_dlext, valid_dl_path, arch, libc,
@@ -70,9 +70,13 @@ const allow_ecryptfs = Ref(false)
 const use_ccache = Ref(false)
 const bootstrap_list = Symbol[]
 
+const artifacts_toml = @path Pkg.Artifacts.find_artifacts_toml(@__FILE__)
+
 function get_bbb_version(dir=@__DIR__, uuid="7f725544-6523-48cd-82d1-3fa08ff4056e")
     # Get BinaryBuilder.jl's version and git sha
-    version = Pkg.TOML.parsefile(joinpath(dir, "..", "Project.toml"))["version"]
+    version = Pkg.activate() do
+        Pkg.Types.EnvCache().project.version
+    end
     try
         # get the gitsha if we can
         repo = LibGit2.GitRepo(dirname(@__DIR__))
@@ -170,9 +174,14 @@ function __init__()
     global runner_override, use_squashfs, allow_ecryptfs
     global use_ccache, storage_cache
 
+    deps_path = joinpath(@__DIR__, "..", "deps")
+    ispath(deps_path) || begin
+        deps_path = joinpath(Base.DEPOT_PATH, "BinaryBuilderBase.jl", "deps")
+        @info "Creating a storage cache at $deps_path"
+    end
     # Allow the user to override the default value for `storage_dir`
     storage_cache[] = get(ENV, "BINARYBUILDER_STORAGE_DIR",
-                          abspath(joinpath(@__DIR__, "..", "deps")))
+                          abspath(deps_path))
 
     # If the user has signalled that they really want us to automatically
     # accept apple EULAs, do that.

--- a/src/BinaryBuilderBase.jl
+++ b/src/BinaryBuilderBase.jl
@@ -71,7 +71,6 @@ const use_ccache = Ref(false)
 const bootstrap_list = Symbol[]
 
 const _artifacts_toml = @path Pkg.Artifacts.find_artifacts_toml(@__FILE__)
-const artifacts_toml = String(_artifacts_toml)
 
 function get_bbb_version(dir=@__DIR__, uuid="7f725544-6523-48cd-82d1-3fa08ff4056e")
     # Get BinaryBuilder.jl's version and git sha

--- a/src/BinaryBuilderBase.jl
+++ b/src/BinaryBuilderBase.jl
@@ -70,7 +70,8 @@ const allow_ecryptfs = Ref(false)
 const use_ccache = Ref(false)
 const bootstrap_list = Symbol[]
 
-const artifacts_toml = @path Pkg.Artifacts.find_artifacts_toml(@__FILE__)
+const _artifacts_toml = @path Pkg.Artifacts.find_artifacts_toml(@__FILE__)
+const artifacts_toml = String(_artifacts_toml)
 
 function get_bbb_version(dir=@__DIR__, uuid="7f725544-6523-48cd-82d1-3fa08ff4056e")
     # Get BinaryBuilder.jl's version and git sha

--- a/src/BinaryBuilderBase.jl
+++ b/src/BinaryBuilderBase.jl
@@ -75,7 +75,13 @@ const _artifacts_toml = @path Pkg.Artifacts.find_artifacts_toml(@__FILE__)
 function get_bbb_version(dir=@__DIR__, uuid="7f725544-6523-48cd-82d1-3fa08ff4056e")
     # Get BinaryBuilder.jl's version and git sha
     version = Pkg.activate(".") do
-        Pkg.Types.EnvCache().project.version
+        Pkg.Types.EnvCache().project.name == "BinaryBuilderBase" ?
+            Pkg.Types.EnvCache().project.version :
+            try
+                Pkg.TOML.parsefile(normpath(Base.find_package("BinaryBuilderBase.jl"), "..", "..", "Project.toml"))["version"]
+            catch e
+                nothing
+            end
     end
     try
         # get the gitsha if we can

--- a/src/DockerRunner.jl
+++ b/src/DockerRunner.jl
@@ -16,6 +16,7 @@ end
 docker_image(version::VersionNumber) = "julia_binarybuilder_rootfs:v$(version)"
 function docker_image(rootfs::CompilerShard)
     name = artifact_name(rootfs)
+    artifacts_toml = String(_artifacts_toml)
     hash = artifact_hash(name, artifacts_toml; platform=rootfs.host)
     return string(
         "julia_binarybuilder_rootfs:",

--- a/src/DockerRunner.jl
+++ b/src/DockerRunner.jl
@@ -16,7 +16,6 @@ end
 docker_image(version::VersionNumber) = "julia_binarybuilder_rootfs:v$(version)"
 function docker_image(rootfs::CompilerShard)
     name = artifact_name(rootfs)
-    artifacts_toml = joinpath(@__DIR__, "..", "Artifacts.toml")
     hash = artifact_hash(name, artifacts_toml; platform=rootfs.host)
     return string(
         "julia_binarybuilder_rootfs:",

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -94,7 +94,6 @@ end
 const ALL_SHARDS = Ref{Union{Vector{CompilerShard},Nothing}}(nothing)
 function all_compiler_shards()::Vector{CompilerShard}
     if ALL_SHARDS[] === nothing
-        artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
         artifact_dict = load_artifacts_toml(artifacts_toml)
 
         ALL_SHARDS[] = CompilerShard[]
@@ -124,7 +123,6 @@ function all_compiler_shards()::Vector{CompilerShard}
 end
 
 function shard_source_artifact_hash(cs::CompilerShard)
-    artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
     name = artifact_name(cs)
     hash = artifact_hash(
         name,
@@ -179,7 +177,6 @@ function mount_path(cs::CompilerShard, build_prefix::AbstractString)
         return joinpath(build_prefix, ".mounts", artifact_name(cs))
     else
         name = artifact_name(cs)
-        artifacts_toml = joinpath(@__DIR__, "..", "Artifacts.toml")
         hash = artifact_hash(name, artifacts_toml; platform=cs.host)
         if hash === nothing
             error("Unable to find artifact $(name) within $(artifacts_toml)")
@@ -254,7 +251,6 @@ function mount(cs::CompilerShard, build_prefix::AbstractString; verbose::Bool = 
     end
 
     # Ensure this artifact is on-disk; hard to mount it if it's not installed
-    artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
     ensure_artifact_installed(artifact_name(cs), artifacts_toml; platform=cs.host, verbose=true)
 
     # Easy out if we're not Linux with a UserNSRunner trying to use a .squashfs
@@ -345,7 +341,6 @@ function macos_sdk_already_installed()
     css = all_compiler_shards()
     macos_artifact_names = artifact_name.(filter(cs -> cs.target !== nothing && Sys.isapple(cs.target::Platform), css))
 
-    artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
     macos_artifact_hashes = artifact_hash.(macos_artifact_names, artifacts_toml; platform=default_host_platform)
 
     # Return `true` if _any_ of these artifacts exist on-disk:
@@ -913,7 +908,6 @@ happens, you don't need an internet connection to build your precious, precious
 binaries.
 """
 function download_all_artifacts(; verbose::Bool = false)
-    artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
     ensure_all_artifacts_installed(
         artifacts_toml;
         include_lazy=true,

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -94,6 +94,7 @@ end
 const ALL_SHARDS = Ref{Union{Vector{CompilerShard},Nothing}}(nothing)
 function all_compiler_shards()::Vector{CompilerShard}
     if ALL_SHARDS[] === nothing
+        artifacts_toml = String(_artifacts_toml)
         artifact_dict = load_artifacts_toml(artifacts_toml)
 
         ALL_SHARDS[] = CompilerShard[]
@@ -124,6 +125,7 @@ end
 
 function shard_source_artifact_hash(cs::CompilerShard)
     name = artifact_name(cs)
+    artifacts_toml = String(_artifacts_toml)
     hash = artifact_hash(
         name,
         artifacts_toml;
@@ -177,6 +179,7 @@ function mount_path(cs::CompilerShard, build_prefix::AbstractString)
         return joinpath(build_prefix, ".mounts", artifact_name(cs))
     else
         name = artifact_name(cs)
+        artifacts_toml = String(_artifacts_toml)
         hash = artifact_hash(name, artifacts_toml; platform=cs.host)
         if hash === nothing
             error("Unable to find artifact $(name) within $(artifacts_toml)")
@@ -251,6 +254,7 @@ function mount(cs::CompilerShard, build_prefix::AbstractString; verbose::Bool = 
     end
 
     # Ensure this artifact is on-disk; hard to mount it if it's not installed
+    artifacts_toml = String(_artifacts_toml)
     ensure_artifact_installed(artifact_name(cs), artifacts_toml; platform=cs.host, verbose=true)
 
     # Easy out if we're not Linux with a UserNSRunner trying to use a .squashfs
@@ -341,6 +345,7 @@ function macos_sdk_already_installed()
     css = all_compiler_shards()
     macos_artifact_names = artifact_name.(filter(cs -> cs.target !== nothing && Sys.isapple(cs.target::Platform), css))
 
+    artifacts_toml = String(_artifacts_toml)
     macos_artifact_hashes = artifact_hash.(macos_artifact_names, artifacts_toml; platform=default_host_platform)
 
     # Return `true` if _any_ of these artifacts exist on-disk:
@@ -908,6 +913,7 @@ happens, you don't need an internet connection to build your precious, precious
 binaries.
 """
 function download_all_artifacts(; verbose::Bool = false)
+    artifacts_toml = String(_artifacts_toml)
     ensure_all_artifacts_installed(
         artifacts_toml;
         include_lazy=true,


### PR DESCRIPTION
Currently `artifact_toml` paths are defined using `@__DIR__`. This hardwires the paths. Any sysimage with BinaryBuilderBase thus becomes non-relocatable. Particularly, any function that downloads artifacts throws an IOerror for not finding `<original_package_location>/Project.toml`

(Similarly `get_bbb_version` is suitably modified)

