### PR TITLE
[RootFS] Update to new build

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2794,24 +2794,24 @@ os = "linux"
 
 [["Rootfs.v2022.2.5.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "eb747defda0f9d34a623ea46eec967e5a5af4108"
+git-tree-sha1 = "45bebe2108ea52c92941030d319eb414727f84dc"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["Rootfs.v2022.2.5.x86_64-linux-musl.squashfs".download]]
-    sha256 = "0b061ef7391e6d469648fa6b737b1670bb2232e337d2fb67ecadfeb5cfe93d41"
+    sha256 = "863437794e9c7a5e7962648ae25008b592bf0cc5b275669f19bc5d8b89c89e12"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2022.2.5/Rootfs.v2022.2.5.x86_64-linux-musl.squashfs.tar.gz"
 
 [["Rootfs.v2022.2.5.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "37c094f1d7333e9949ddce21d54b55bdcae9e760"
+git-tree-sha1 = "34dae1bda740e22fb6bb40b54c6fac8ebd6ce7a3"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["Rootfs.v2022.2.5.x86_64-linux-musl.unpacked".download]]
-    sha256 = "f6e95f1fc267dad68a5357e1e6e5efa452a45dc2ad33f3a61b864f9458ed9f9d"
+    sha256 = "1df8588e642ce3efb26076fabf43dcdbcbfa8e509a8e980d890a649728efee52"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2022.2.5/Rootfs.v2022.2.5.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustBase.v1.57.0.x86_64-linux-musl.squashfs"]]

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2792,27 +2792,27 @@ os = "linux"
     sha256 = "5cc8c42875360e9ff28e49135556363bdb43a837d660fbd86fafe64529d2abcd"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/PlatformSupport-v2021.8.10/PlatformSupport-x86_64-w64-mingw32.v2021.8.10.x86_64-linux-musl.unpacked.tar.gz"
 
-[["Rootfs.v2021.7.13.x86_64-linux-musl.squashfs"]]
+[["Rootfs.v2022.2.5.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "5795ee9f2eca2284bfb80611ac2accfc89998e0b"
+git-tree-sha1 = "eb747defda0f9d34a623ea46eec967e5a5af4108"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["Rootfs.v2021.7.13.x86_64-linux-musl.squashfs".download]]
-    sha256 = "1bb755ffdf003fa1a1457cfbc3ad44e770038181e5a1138a54b0d60de507f692"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2021.7.13/Rootfs.v2021.7.13.x86_64-linux-musl.squashfs.tar.gz"
+    [["Rootfs.v2022.2.5.x86_64-linux-musl.squashfs".download]]
+    sha256 = "0b061ef7391e6d469648fa6b737b1670bb2232e337d2fb67ecadfeb5cfe93d41"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2022.2.5/Rootfs.v2022.2.5.x86_64-linux-musl.squashfs.tar.gz"
 
-[["Rootfs.v2021.7.13.x86_64-linux-musl.unpacked"]]
+[["Rootfs.v2022.2.5.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "56df63e8265adb2316d6599632113da025545434"
+git-tree-sha1 = "37c094f1d7333e9949ddce21d54b55bdcae9e760"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["Rootfs.v2021.7.13.x86_64-linux-musl.unpacked".download]]
-    sha256 = "aa5aef6b4c68b28c135da87d3d0169e142a84b89d556748f3f37d30355b9ca17"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2021.7.13/Rootfs.v2021.7.13.x86_64-linux-musl.unpacked.tar.gz"
+    [["Rootfs.v2022.2.5.x86_64-linux-musl.unpacked".download]]
+    sha256 = "f6e95f1fc267dad68a5357e1e6e5efa452a45dc2ad33f3a61b864f9458ed9f9d"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2022.2.5/Rootfs.v2022.2.5.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustBase.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -521,7 +521,7 @@ consists of four shards, but that may not always be the case.
 """
 function choose_shards(p::AbstractPlatform;
             compilers::Vector{Symbol} = [:c],
-            rootfs_build::VersionNumber=v"2021.7.13",
+            rootfs_build::VersionNumber=v"2022.2.5",
             ps_build::VersionNumber=v"2021.08.10",
             GCC_builds::Vector{GCCBuild}=available_gcc_builds,
             LLVM_builds::Vector{LLVMBuild}=available_llvm_builds,


### PR DESCRIPTION
Changes:

* updated Alpine Linux base image to v3.15.0
* updated Meson to v0.61.1
* updated patchelf to v0.14.3
* removed `unrar` from the base image (it isn't available in Alpine Linux
  3.15.0)
* improved `flagon` script to deal with `-Wl` flags

Companion PR to https://github.com/JuliaPackaging/Yggdrasil/pull/4364