### PR TITLE
[Runner] Generate some fake XCode tools which are occasionally needed

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -807,12 +807,20 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     if os(platform) == "macos"
         # `sw_vers -productVersion` is needed to make CMake correctly initialise the macOS
         # platform, ref: <https://github.com/JuliaPackaging/Yggdrasil/pull/4403>.  In the
-        # future we may add more arguments.
+        # future we may add more arguments, see
+        # <https://www.unix.com/man-page/osx/1/sw_vers/> for reference.
+        product_version = macos_version(platform)
+        product_name = VersionNumber(product_version) < v"10.12" ? "Mac OS X" : "macOS"
         sw_vers_path = joinpath(bin_path, triplet(platform), "sw_vers")
         write(sw_vers_path, """
               #!/bin/sh
-              if [[ "\${*}" == "-productVersion" ]]; then
-                  echo "$(macos_version(platform))"
+              if [[ -z "\${@}" ]]; then
+                  echo "ProductName:    $(product_name)"
+                  echo "ProductVersion: $(product_version)"
+              elif [[ "\${@}" == "-productName" ]]; then
+                  echo "$(product_name)"
+              elif [[ "\${@}" == "-productVersion" ]]; then
+                  echo "$(product_version)"
               fi
               """)
         chmod(sw_vers_path, 0o775)

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -802,6 +802,31 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     for tool in default_tools
         symlink("$(target)-$(tool)", joinpath(bin_path, triplet(platform), tool))
     end
+
+    # Generate other fake system-specific tools.
+    if os(platform) == "macos"
+        # `sw_vers -productVersion` is needed to make CMake correctly initialise the macOS
+        # platform, ref: <https://github.com/JuliaPackaging/Yggdrasil/pull/4403>.  In the
+        # future we may add more arguments.
+        sw_vers_path = joinpath(bin_path, triplet(platform), "sw_vers")
+        write(sw_vers_path, """
+              #!/bin/sh
+              if [[ "\${*}" == "-productVersion" ]]; then
+                  echo "$(macos_version(platform))"
+              fi
+              """)
+        chmod(sw_vers_path, 0o775)
+
+        # `xcrun` is another macOS-specific tool, which is occasionally needed to run some
+        # commands, for example for the CGO linker.  Ref:
+        # <https://github.com/JuliaPackaging/Yggdrasil/pull/2962>.
+        xcrun_path = joinpath(bin_path, triplet(platform), "xcrun")
+        write(xcrun_path, """
+              #!/bin/sh
+              exec "\${@}"
+              """)
+        chmod(xcrun_path, 0o775)
+    end
 end
 
 # Translation mappers for our target names to cargo-compatible ones.  See


### PR DESCRIPTION
With these two simple scripts I'm able to compile for macOS `licensecheck` without [this manual hack](https://github.com/JuliaPackaging/Yggdrasil/blob/2b0395821db522fa190e749d4d7fd670a5297643/L/licensecheck/build_tarballs.jl#L17-L24), and LLVM 13.0.1 from https://github.com/JuliaPackaging/Yggdrasil/pull/4403 without having to manually create a fake `sw_vers`