### PR TITLE
Fix architecture of `default_host_platform` to `x86_64`

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -28,15 +28,16 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JLLWrappers]]
-git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
+deps = ["Preferences"]
+git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.2.0"
+version = "1.4.1"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
+version = "0.21.3"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -82,19 +83,25 @@ uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
 [[OutputCollectors]]
-git-tree-sha1 = "d86c19b7fa8ad6a4dc8ec2c726642cc6291b2941"
+git-tree-sha1 = "5d3f2b3b2e2a9d7d6f1774c78e94530ac7f360cc"
 uuid = "6c11c7d4-943b-4e2b-80de-f2cfc2930a8c"
-version = "0.1.0"
+version = "0.1.1"
 
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "50c9a9ed8c714945e01cd53a21007ed3865ed714"
+git-tree-sha1 = "13468f237353112a01b2d6b32f3d0f80219944aa"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.15"
+version = "2.2.2"
 
 [[Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "2cf929d64681236a2e074ffafb8d568733d2e6af"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.3"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -113,9 +120,9 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [[Scratch]]
 deps = ["Dates"]
-git-tree-sha1 = "ad4b278adb62d185bbcb6864dc24959ab0627bf6"
+git-tree-sha1 = "0b4b7f1393cff97c33891da2a0bf69c6ed241fda"
 uuid = "6c6a2e73-6563-6170-7368-637461726353"
-version = "1.0.3"
+version = "1.1.0"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -142,9 +149,9 @@ uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TranscodingStreams]]
 deps = ["Random", "Test"]
-git-tree-sha1 = "7c53c35547de1c5b9d46a4797cf6d8253807108c"
+git-tree-sha1 = "216b95ea110b5972db65aa90f88d8d89dcb8851c"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.9.5"
+version = "0.9.6"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -167,6 +174,6 @@ uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [[pigz_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "8c379a72c82099ceb4be53f4f427690376279052"
+git-tree-sha1 = "3c0c0b0c133b6ab53e1af05dc526091ce8781f16"
 uuid = "1bc43ea1-30af-5bc8-a9d4-c018457e6e3e"
-version = "2.5.0+0"
+version = "2.7.0+0"

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -15,7 +15,7 @@ const AnyRedirectable = Union{Base.AbstractCmd, Base.TTY, IOStream, IOBuffer}
 
 The default host platform in the build environment.
 """
-const default_host_platform = Sys.islinux(HostPlatform()) ? Platform(arch(HostPlatform()), "linux"; libc="musl", cxxstring_abi="cxx11") : Platform("x86_64", "linux"; libc="musl", cxxstring_abi="cxx11")
+const default_host_platform = Platform("x86_64", "linux"; libc="musl", cxxstring_abi="cxx11")
 
 function nbits(p::AbstractPlatform)
     if arch(p) in ("i686", "armv6l", "armv7l")

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -8,7 +8,8 @@ const AnyRedirectable = Union{Base.AbstractCmd, Base.TTY, IOStream, IOBuffer}
 # Host platform _must_ match the C++ string ABI of the binaries we get from the
 # repositories.  Note: when preferred_gcc_version=v"4" we can't really build for
 # that C++ string ABI :-(
-# Non-Linux will end up using DockerRunner and we need (and can use) x86 here.    
+# Non-Linux platforms *should* end up using DockerRunner
+# so we can safely assume x86_64 support
 """
     default_host_platform
 

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -8,8 +8,6 @@ const AnyRedirectable = Union{Base.AbstractCmd, Base.TTY, IOStream, IOBuffer}
 # Host platform _must_ match the C++ string ABI of the binaries we get from the
 # repositories.  Note: when preferred_gcc_version=v"4" we can't really build for
 # that C++ string ABI :-(
-# Non-Linux platforms *should* end up using DockerRunner
-# so we can safely assume x86_64 support
 """
     default_host_platform
 

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -8,12 +8,13 @@ const AnyRedirectable = Union{Base.AbstractCmd, Base.TTY, IOStream, IOBuffer}
 # Host platform _must_ match the C++ string ABI of the binaries we get from the
 # repositories.  Note: when preferred_gcc_version=v"4" we can't really build for
 # that C++ string ABI :-(
+# Non-Linux will end up using DockerRunner and we need (and can use) x86 here.    
 """
     default_host_platform
 
 The default host platform in the build environment.
 """
-const default_host_platform = Platform(arch(HostPlatform()), "linux"; libc="musl", cxxstring_abi="cxx11")
+const default_host_platform = Sys.islinux(HostPlatform()) ? Platform(arch(HostPlatform()), "linux"; libc="musl", cxxstring_abi="cxx11") : Platform("x86_64", "linux"; libc="musl", cxxstring_abi="cxx11")
 
 function nbits(p::AbstractPlatform)
     if arch(p) in ("i686", "armv6l", "armv7l")

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -122,11 +122,11 @@ end
             dependencies = [
                 Dependency("Zlib_jll")
             ]
-            platform = HostPlatform()
+            platform = HostPlatform(parse(Platform, join(["x86_64", split(Base.BinaryPlatforms.host_triplet(), "-")[2:end]...], "-")))
             ap = @test_logs setup_dependencies(prefix, getpkg.(dependencies), platform)
             @test "libz." * platform_dlext(platform) in readdir(last(libdirs(Prefix(destdir(dir, platform)))))
             @test "zlib.h" in readdir(joinpath(destdir(dir, platform), "include"))
-            @test readdir(joinpath(destdir(dir, platform), "logs")) == ["Zlib.log.gz"]
+            @test "Zlib.log.gz" in readdir(joinpath(destdir(dir, platform), "logs"))
 
             # Make sure the directories are emptied by `cleanup_dependencies`
             @test_nowarn cleanup_dependencies(prefix, ap, platform)

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -122,11 +122,17 @@ end
             dependencies = [
                 Dependency("Zlib_jll")
             ]
-            platform = HostPlatform(parse(Platform, join(["x86_64", split(Base.BinaryPlatforms.host_triplet(), "-")[2:end]...], "-")))
+            platform = HostPlatform()
             ap = @test_logs setup_dependencies(prefix, getpkg.(dependencies), platform)
             @test "libz." * platform_dlext(platform) in readdir(last(libdirs(Prefix(destdir(dir, platform)))))
             @test "zlib.h" in readdir(joinpath(destdir(dir, platform), "include"))
-            @test "Zlib.log.gz" in readdir(joinpath(destdir(dir, platform), "logs"))
+
+            if os(platform) == "macos"
+                zlib_log_files = ["Zlib.log.gz", "fix_identity_mismatch_libz.1.2.11.dylib.log.gz", "ldid_libz.1.2.11.dylib.log.gz"]
+            else
+                zlib_log_files = ["Zlib.log.gz"]
+            end
+            @test readdir(joinpath(destdir(dir, platform), "logs")) == zlib_log_files
 
             # Make sure the directories are emptied by `cleanup_dependencies`
             @test_nowarn cleanup_dependencies(prefix, ap, platform)

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -35,11 +35,10 @@ end
             @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == isecfs
             @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == isecfs
             @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == isecfs
-        else
+    elseif Sys.islinux()
             @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == (false, "/proc")
             @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == (false, "/proc/")
             @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == (false, "/proc/not_a_file")
-        end
     end
 
     if isa(preferred_runner(), BinaryBuilderBase.DockerRunner)

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -103,8 +103,7 @@ end
     @testset "Compilation - C++ string ABI" begin
         mktempdir() do dir
             # Host is x86_64-linux-musl-cxx11 and target is x86_64-linux-musl-cxx03
-            platform = HostPlatform(parse(Platform, join(["x86_64", split(Base.BinaryPlatforms.host_triplet(), "-")[2:end]...], "-")))
-            ur = preferred_runner()(dir; platform=Platform(arch(platform), "linux"; libc="musl", cxxstring_abi="cxx03"), preferred_gcc_version=v"5")
+            ur = preferred_runner()(dir; platform=Platform("x86_64", "linux"; libc="musl", cxxstring_abi="cxx03"), preferred_gcc_version=v"5")
             iobuff = IOBuffer()
             test_script = raw"""
             set -e

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -30,18 +30,18 @@ end
 # Are we using docker? If so, test that the docker runner works...
 @testset "Runner utilities" begin
     # Test that is_ecryptfs works for something we're certain isn't encrypted
-    if Sys.islinux() && isdir("/proc")
-            isecfs = (false, "/proc/")
-            @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == isecfs
-            @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == isecfs
-            @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == isecfs
-    elseif Sys.islinux()
-            @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == (false, "/proc")
-            @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == (false, "/proc/")
-            @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == (false, "/proc/not_a_file")
-    end
-
-    if isa(preferred_runner(), BinaryBuilderBase.DockerRunner)
+    if isa(preferred_runner(), BinaryBuilderBase.UserNSRunner)
+        if isdir("/proc")
+                isecfs = (false, "/proc/")
+                @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == isecfs
+                @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == isecfs
+                @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == isecfs
+        else
+                @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == (false, "/proc")
+                @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == (false, "/proc/")
+                @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == (false, "/proc/not_a_file")
+        end
+    elseif isa(preferred_runner(), BinaryBuilderBase.DockerRunner)
         @testset "Docker image importing" begin
             # First, delete the docker image, in case it already existed
             BinaryBuilderBase.delete_docker_image()

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -30,18 +30,19 @@ end
 # Are we using docker? If so, test that the docker runner works...
 @testset "Runner utilities" begin
     # Test that is_ecryptfs works for something we're certain isn't encrypted
-    if isa(preferred_runner(), BinaryBuilderBase.UserNSRunner)
-        if isdir("/proc")
-                isecfs = (false, "/proc/")
-                @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == isecfs
-                @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == isecfs
-                @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == isecfs
-        else
-                @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == (false, "/proc")
-                @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == (false, "/proc/")
-                @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == (false, "/proc/not_a_file")
-        end
-    elseif isa(preferred_runner(), BinaryBuilderBase.DockerRunner)
+
+    if isdir("/proc") && Sys.islinux()
+            isecfs = (false, "/proc/")
+            @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == isecfs
+            @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == isecfs
+            @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == isecfs
+    elseif Sys.islinux()
+            @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == (false, "/proc")
+            @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == (false, "/proc/")
+            @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == (false, "/proc/not_a_file")
+    end
+
+    if isa(preferred_runner(), BinaryBuilderBase.DockerRunner)
         @testset "Docker image importing" begin
             # First, delete the docker image, in case it already existed
             BinaryBuilderBase.delete_docker_image()

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -32,14 +32,14 @@ end
     # Test that is_ecryptfs works for something we're certain isn't encrypted
 
     if isdir("/proc") && Sys.islinux()
-            isecfs = (false, "/proc/")
-            @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == isecfs
-            @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == isecfs
-            @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == isecfs
+        isecfs = (false, "/proc/")
+        @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == isecfs
+        @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == isecfs
+        @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == isecfs
     elseif Sys.islinux()
-            @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == (false, "/proc")
-            @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == (false, "/proc/")
-            @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == (false, "/proc/not_a_file")
+        @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == (false, "/proc")
+        @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == (false, "/proc/")
+        @test_logs (:info, "Checking to see if /proc/not_a_file is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/not_a_file"; verbose=true) == (false, "/proc/not_a_file")
     end
 
     if isa(preferred_runner(), BinaryBuilderBase.DockerRunner)

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -30,8 +30,7 @@ end
 # Are we using docker? If so, test that the docker runner works...
 @testset "Runner utilities" begin
     # Test that is_ecryptfs works for something we're certain isn't encrypted
-    if Sys.islinux(HostPlatform())
-        if isdir("/proc")
+    if Sys.islinux() && isdir("/proc")
             isecfs = (false, "/proc/")
             @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc"; verbose=true) == isecfs
             @test_logs (:info, "Checking to see if /proc/ is encrypted...") @test BinaryBuilderBase.is_ecryptfs("/proc/"; verbose=true) == isecfs


### PR DESCRIPTION
For platforms which are DockerRunner supported, use `x86_64` as the `default_host_platform` architecture.