### PR TITLE
Bump Rootfs to include new Musl build

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2858,27 +2858,27 @@ os = "linux"
     sha256 = "5cc8c42875360e9ff28e49135556363bdb43a837d660fbd86fafe64529d2abcd"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/PlatformSupport-v2021.8.10/PlatformSupport-x86_64-w64-mingw32.v2021.8.10.x86_64-linux-musl.unpacked.tar.gz"
 
-[["Rootfs.v2022.3.5.x86_64-linux-musl.squashfs"]]
+[["Rootfs.v2022.4.15.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "711007e9f06dbd041af01abf10baefef4db58fbd"
+git-tree-sha1 = "482f773e04ac1199bc2d0df2d145b5bff46489cc"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["Rootfs.v2022.3.5.x86_64-linux-musl.squashfs".download]]
-    sha256 = "1f90cf9ef2ea181bf985873ba9305858a6c1b67f834eca3c63d5628bdf5c40ae"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2022.3.5/Rootfs.v2022.3.5.x86_64-linux-musl.squashfs.tar.gz"
+    [["Rootfs.v2022.4.15.x86_64-linux-musl.squashfs".download]]
+    sha256 = "b23a0d20e5f026d0b03f4bcf4fbc3ba07f56f45b47bda91dc5532442dd404d39"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2022.4.15/Rootfs.v2022.4.15.x86_64-linux-musl.squashfs.tar.gz"
 
-[["Rootfs.v2022.3.5.x86_64-linux-musl.unpacked"]]
+[["Rootfs.v2022.4.15.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "35b8a8925cc319dd6caeb3b12c58e691dd61e50c"
+git-tree-sha1 = "d0c08357d84c092c9d6a8bad715001ad33e3d5d5"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["Rootfs.v2022.3.5.x86_64-linux-musl.unpacked".download]]
-    sha256 = "5562fd59712e37c941001d207a3d49b6d951932874bfa1795132bd1e5bb93397"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2022.3.5/Rootfs.v2022.3.5.x86_64-linux-musl.unpacked.tar.gz"
+    [["Rootfs.v2022.4.15.x86_64-linux-musl.unpacked".download]]
+    sha256 = "2f6e972cf3b15c2f7c84fb1fb5799f0b44190f38976d70b77a347e1015432b9c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2022.4.15/Rootfs.v2022.4.15.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustBase.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -544,7 +544,8 @@ consists of four shards, but that may not always be the case.
 """
 function choose_shards(p::AbstractPlatform;
             compilers::Vector{Symbol} = [:c],
-            rootfs_build::VersionNumber=v"2022.3.5",
+            # We always just use the latest Rootfs embedded within our Artifacts.toml
+            rootfs_build::VersionNumber=last(BinaryBuilderBase.get_available_builds("Rootfs")),
             ps_build::VersionNumber=v"2021.08.10",
             GCC_builds::Vector{GCCBuild}=available_gcc_builds,
             LLVM_builds::Vector{LLVMBuild}=available_llvm_builds,


### PR DESCRIPTION
Includes https://github.com/JuliaPackaging/Yggdrasil/pull/4762 and https://github.com/JuliaPackaging/Yggdrasil/pull/4753/commits/c7bd98f77b6f14b9ac42c78a99d4ef659b83bbf3