### PR TITLE
[Platforms] Restore previous compilation flags for base armv7l architecture

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.10.0"
+version = "1.10.1"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/Platforms.jl
+++ b/src/Platforms.jl
@@ -110,7 +110,7 @@ const ARCHITECTURE_FLAGS = Dict(
         ),
         "armv7l" => OrderedDict(
             # Base armv7l architecture, with the most basic of FPU's
-            "armv7l"   => ["-mcpu=generic-armv7-a", "-mfpu=vfpv3", "-mfloat-abi=hard"],
+            "armv7l"   => ["-march=armv7-a", "-mtune=generic-armv7-a", "-mfpu=vfpv3", "-mfloat-abi=hard"],
             # armv7l plus NEON and vfpv4, (Raspberry Pi 2B+, RK3328, most boards Elliot has access to)
             "neonvfpv4" => ["-mcpu=cortex-a53", "-mfpu=neon-vfpv4", "-mfloat-abi=hard"],
         ),


### PR DESCRIPTION
Using only `-mcpu=generic-armv7-a` causes an error in the assembler with GCC 5:

```console
% julia --compile=min -e 'using BinaryBuilderBase; BinaryBuilderBase.runshell(Platform("armv7l", "linux"); preferred_gcc_version=v"5")'
sandbox:${WORKSPACE} # echo 'int main(){}' | /opt/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc -x c - -mcpu=generic-armv7-a
Assembler messages:
Error: unknown cpu `generic-armv7-a'
Error: unrecognized option -mcpu=generic-armv7-a
```

We may have to revise how GCC is compiled for this platform, but this is for
another day.

Ref: https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/238#pullrequestreview-943928912