### PR TITLE
Fix some issues reported on Slack

### DIFF
--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -297,6 +297,9 @@ function setup(source::SetupSource{ArchiveSource}, targetdir, verbose; tar_flags
 end
 
 function setup(source::SetupSource{FileSource}, target, verbose)
+    if isdir(target)
+        target = joinpath(target, basename(source.path))
+    end
     if verbose
         @info "Copying $(basename(source.path)) in $(basename(target))..."
     end

--- a/src/Sources.jl
+++ b/src/Sources.jl
@@ -114,7 +114,7 @@ SetupSource{T}(path::String, hash::String, target::String) where {T} =
 function SetupSource(url::String, path::String, hash::String, target::String)
     if endswith(url, ".git")
         return SetupSource{GitSource}(path, hash, target)
-    elseif any(endswith(url, ext) for ext in archive_extensions)
+    elseif any(endswith(path, ext) for ext in archive_extensions)
         return SetupSource{ArchiveSource}(path, hash, target)
     else
         return SetupSource{FileSource}(path, hash, target)

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -11,10 +11,10 @@ using JSON
     @test FileSource("https://curl.haxx.se/ca/cacert-2020-01-01.pem", "adf770dfd574a0d6026bfaa270cb6879b063957177a991d453ff1d302c02081f").filename == "cacert-2020-01-01.pem"
     @test FileSource("https://curl.haxx.se/ca/cacert-2020-01-01.pem", "adf770dfd574a0d6026bfaa270cb6879b063957177a991d453ff1d302c02081f"; filename="cacert.pem").filename == "cacert.pem"
 
-    @test SetupSource("https://ftp.gnu.org/gnu/wget/wget-1.20.3.tar.gz", "", "", "") isa SetupSource{ArchiveSource}
-    @test SetupSource("https://ftp.gnu.org/gnu/wget/wget-1.20.3.zip", "", "", "")    isa SetupSource{ArchiveSource}
-    @test SetupSource("https://github.com/jedisct1/libsodium.git", "", "", "")       isa SetupSource{GitSource}
-    @test SetupSource("https://curl.haxx.se/ca/cacert-2020-01-01.pem", "", "", "")   isa SetupSource{FileSource}
+    @test SetupSource("https://ftp.gnu.org/gnu/wget/wget-1.20.3.tar.gz", "wget-1.20.3.tar.gz", "", "") isa SetupSource{ArchiveSource}
+    @test SetupSource("https://ftp.gnu.org/gnu/wget/wget-1.20.3.zip", "wget-1.20.3.zip", "", "")    isa SetupSource{ArchiveSource}
+    @test SetupSource("https://github.com/jedisct1/libsodium.git", "libsodium.git", "", "")       isa SetupSource{GitSource}
+    @test SetupSource("https://curl.haxx.se/ca/cacert-2020-01-01.pem", "cacert-2020-01-01.pem", "", "")   isa SetupSource{FileSource}
 
     @testset "Download and setup" begin
         mktempdir() do dir


### PR DESCRIPTION
To reproduce the issue, try to run a wizard session based off of the file `https://github.com/ashwani-rathee/io-project/blob/main/gifwrapper/gen/libgifextra.zip?raw=true`.  You eventually get:

```
ArgumentError: '/tmp/jl_geNiLj/JIG6zjMf/srcdir' exists. `force=true` is required to remove '/tmp/jl_geNiLj/JIG6zjMf/srcdir' before copying.
Stacktrace:
  [1] checkfor_mv_cp_cptree(src::String, dst::String, txt::String; force::Bool)
    @ Base.Filesystem ./file.jl:312
  [2] cp(src::String, dst::String; force::Bool, follow_symlinks::Bool)
    @ Base.Filesystem ./file.jl:349
  [3] cp
    @ ./file.jl:349 [inlined]
  [4] setup(source::BinaryBuilderBase.SetupSource{FileSource}, target::String, verbose::Bool)
    @ BinaryBuilderBase ~/.julia/packages/BinaryBuilderBase/IKZGk/src/Prefix.jl:309
```

Because the `.zip` file is incorrectly seen as a `FileSource`, rather than an `ArchiveSource`.