### PR TITLE
Add support for building sanitizer-enabled jlls

### DIFF
--- a/src/Platforms.jl
+++ b/src/Platforms.jl
@@ -146,3 +146,4 @@ const ARCHITECTURE_FLAGS = Dict(
     ),
 )
 march(p::AbstractPlatform; default=nothing) = get(tags(p), "march", default)
+sanitize(p::AbstractPlatform; default=nothing) = get(tags(p), "sanitize", default)

--- a/src/Products.jl
+++ b/src/Products.jl
@@ -222,7 +222,7 @@ function locate(lp::LibraryProduct, prefix::Prefix; platform::AbstractPlatform =
                     end
 
                     # If it does, try to `dlopen()` it if the current platform is good
-                    if (!lp.dont_dlopen && !skip_dlopen) && platforms_match(platform, HostPlatform())
+                    if (!lp.dont_dlopen && !skip_dlopen) && platforms_match(platform, HostPlatform()) && sanitize(platform) == sanitize(HostPlatform())
                         if isolate
                             # Isolated dlopen is a lot slower, but safer
                             if success(`$(Base.julia_cmd()) --startup-file=no -e "import Libdl; Libdl.dlopen(\"$dl_path\")"`)

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -469,6 +469,12 @@ function gcc_version(p::AbstractPlatform,GCC_builds::Vector{GCCBuild},
         GCC_builds = filter(b -> getversion(b) ≥ v"5", GCC_builds)
     end
 
+    # Msan uses clang, which emits R_X86_64_REX_GOTPCRELX, and thus requires
+    # binutils >= 2.26.
+    if sanitize(p) in ("memory", "address")
+        GCC_builds = filter(b -> getversion(b) ≥ v"6", GCC_builds)
+    end
+
     # Filter the possible GCC versions depending on the microarchitecture
     if march(p) in ("avx", "avx2", "neonvfpv4")
         # "sandybridge", "haswell", "cortex-a53" introduced in GCC v4.9.0:

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -471,7 +471,7 @@ function gcc_version(p::AbstractPlatform,GCC_builds::Vector{GCCBuild},
 
     # Msan uses clang, which emits R_X86_64_REX_GOTPCRELX, and thus requires
     # binutils >= 2.26.
-    if sanitize(p) in ("memory", "address")
+    if sanitize(p) in ("memory", "memory_origins", "address")
         GCC_builds = filter(b -> getversion(b) ≥ v"6", GCC_builds)
     end
 

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -362,6 +362,8 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         san = sanitize(p)
         if sanitize(p) !== nothing
             if sanitize(p) == "memory"
+                append!(flags, ["-fsanitize=memory"])
+            elseif sanitize(p) == "memory_origins"
                 append!(flags, ["-fsanitize=memory", "-fsanitize-memory-track-origins", "-fno-omit-frame-pointer"])
             elseif sanitize(p) == "address"
                 append!(flags, ["-fsanitize=address"])
@@ -376,6 +378,8 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         if sanitize(p) !== nothing
             if sanitize(p) == "memory"
                 append!(flags, ["-fsanitize=memory"])
+            elseif sanitize(p) == "memory_origins"
+                append!(flags, ["-fsanitize=memory", "-fsanitize-memory-track-origins", "-fno-omit-frame-pointer"])
             elseif sanitize(p) == "address"
                 append!(flags, ["-fsanitize=address"])
             elseif sanitize(p) == "thread"
@@ -551,14 +555,14 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     # support, but is claimed to be incompatbile with the LLVM version (that we use for our
     # JIT-generated code)
     function cc(io::IO, p::AbstractPlatform)
-        if Sys.isbsd(p) || sanitize(p) in ("memory", "address")
+        if Sys.isbsd(p) || sanitize(p) in ("memory", "memory_origins", "address")
             return clang(io, p)
         else
             return gcc(io, p)
         end
     end
     function cxx(io::IO, p::AbstractPlatform)
-        if Sys.isbsd(p) || sanitize(p) in ("memory", "address")
+        if Sys.isbsd(p) || sanitize(p) in ("memory", "memory_origins", "address")
             return clangxx(io, p)
         else
             return gxx(io, p)


### PR DESCRIPTION
This adds support for automatically adding the appropriate `-fsanitize=`
flags when the platform includes a `sanitizer` tag. This is particularly
intended for msan, which requires that all .so's in the system are built
using it, but could be useful for other sanitizers also.

There's a couple annoyances. One is that we don't currently actually ship
the sanitizer runtime libraries in our rootfs. Thus, if we want to start
using this, we'd have to add a BuildDependency on LLVMCompilerRT_jll and
manually copy the runtime libraries into place. Not the end of the world,
but certainly a wart.

The other issue is that `platforms_match` (which is defined in Base) of
course currently ignores the `sanitizer` tag. In theory it is possible
to add a custom compare strategy, but since we're specifying the target
by triplet, we can't really add that. Easy enough to add manually here,
but does make me wonder whether the custom compare strategies in Base
actually fit the use case.