### PR TITLE
[Runner] Define function `prefer_clang`

### DIFF
--- a/src/BuildToolchains.jl
+++ b/src/BuildToolchains.jl
@@ -234,7 +234,7 @@ function generate_toolchain_files!(platform::AbstractPlatform, envs::Dict{String
         symlink_if_exists(target, link) = ispath(joinpath(dir, target)) && symlink(target, link)
 
         # On FreeBSD and MacOS we actually want to default to clang, otherwise gcc
-        if Sys.isbsd(p) || sanitize(p) in ("memory", "memory_origins", "address") 
+        if prefer_clang(p)
             symlink_if_exists("host_$(aatriplet(p))_clang.cmake", joinpath(dir, "host_$(aatriplet(p)).cmake"))
             symlink_if_exists("host_$(aatriplet(p))_clang.meson", joinpath(dir, "host_$(aatriplet(p)).meson"))
             symlink_if_exists("target_$(aatriplet(p))_clang.cmake", joinpath(dir, "target_$(aatriplet(p)).cmake"))

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -137,6 +137,10 @@ function macos_version(p::AbstractPlatform)
     return macos_version(version.major)
 end
 
+# Platforms for which Clang should be the default compiler.
+prefer_clang(p::AbstractPlatform) =
+    Sys.isbsd(p) || sanitize(p) in ("memory", "memory_origins", "address")
+
 """
     generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::AbstractString,
                                 host_platform::AbstractPlatform = $(repr(default_host_platform)),
@@ -555,14 +559,14 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     # support, but is claimed to be incompatbile with the LLVM version (that we use for our
     # JIT-generated code)
     function cc(io::IO, p::AbstractPlatform)
-        if Sys.isbsd(p) || sanitize(p) in ("memory", "memory_origins", "address")
+        if prefer_clang(p)
             return clang(io, p)
         else
             return gcc(io, p)
         end
     end
     function cxx(io::IO, p::AbstractPlatform)
-        if Sys.isbsd(p) || sanitize(p) in ("memory", "memory_origins", "address")
+        if prefer_clang(p)
             return clangxx(io, p)
         else
             return gxx(io, p)

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -1,6 +1,6 @@
 using Test
 using BinaryBuilderBase
-using BinaryBuilderBase: platform_dlext, platform_exeext
+using BinaryBuilderBase: platform_dlext, platform_exeext, prefer_clang
 using Pkg
 
 @testset "Wrappers utilities" begin
@@ -25,6 +25,12 @@ using Pkg
     @test platform_exeext(Platform("x86_64", "linux"; march="avx512")) == ""
 
     @test aatriplet(Platform("x86_64", "linux"; libc="glibc", libgfortran_version=v"4.0.0", march="avx", cuda="9.2")) == "x86_64-linux-gnu"
+
+    @test prefer_clang(Platform("x86_64", "freebsd"))
+    @test prefer_clang(Platform("aarch64", "macos"))
+    @test !prefer_clang(Platform("x86_64", "linux"))
+    @test prefer_clang(Platform("x86_64", "linux"; sanitize="memory"))
+    @test !prefer_clang(Platform("x86_64", "linux"; sanitize="thread"))
 end
 
 # Are we using docker? If so, test that the docker runner works...


### PR DESCRIPTION
This allows us to consistently define for which platforms we want to use Clang
as default compiler.

Follow up to https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/258#discussion_r954091351