### PR TITLE
Move -rtlib and friends to linker flags

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -331,10 +331,6 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             append!(flags, [
                 # Find GCC toolchain here (for things like libgcc_s)
                 "--gcc-toolchain=/opt/$(aatriplet(p))"
-                # Use libgcc as the C runtime library
-                "-rtlib=libgcc"
-                # Use libstdc++ as the C++ runtime library
-                "-stdlib=libstdc++"
             ])
         end
         return flags
@@ -424,7 +420,14 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         if Sys.isbsd(p)
             push!(flags, "-L/opt/$(aatriplet(p))/$(aatriplet(p))/lib")
         end
-
+        if !Sys.isbsd(p)
+            append!(flags, [
+                # Use libgcc as the C runtime library
+                "-rtlib=libgcc"
+                # Use libstdc++ as the C++ runtime library
+                "-stdlib=libstdc++"
+            ])
+        end
         # we want to use a particular linker with clang.  But we want to avoid warnings about unused
         # flags when just compiling, so we put it into "linker-only flags".
         push!(flags, "-fuse-ld=$(aatriplet(p))")

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -140,7 +140,7 @@ end
             clang -Werror -shared test.c -o test.\${dlext}
             """
             cmd = `/bin/bash -c "$(test_script)"`
-            @test run(ur, cmd, iobuff; tee_stream=devnull) broken=platform in [Platform("armv7l", "linux", "musl"), Platform("armv6l", "linux", "musl")]
+            @test run(ur, cmd, iobuff; tee_stream=devnull) broken=platform in [Platform("armv7l", "linux"; libc="musl"), Platform("armv6l", "linux"; libc="musl")]
             seekstart(iobuff)
             output = String(read(iobuff))
             @test (occursin("error", output) || occursin("warning", output)) broken=platform in [Platform("armv7l", "linux", "musl"), Platform("armv6l", "linux", "musl")]

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -123,6 +123,29 @@ end
         end
     end
 
+    # Test that we get no warnings when compiling without linking and when building a shared lib with clang
+    @testset "Clang - $(platform)" for platform in platforms
+        mktempdir() do dir
+            ur = preferred_runner()(dir; platform=platform)
+            iobuff = IOBuffer()
+            test_c = """
+            int test(void) {
+                return 0;
+            }
+            """
+            test_script = """
+            set -e
+            echo '$(test_c)' > test.c
+            clang -Werror -c test.c
+            clang -Werror -shared test.c -o test.\${dlext}
+            """
+            cmd = `/bin/bash -c "$(test_script)"`
+            @test run(ur, cmd, iobuff; tee_stream=devnull) broken=Sys.iswindows(platform)
+            seekstart(iobuff)
+            @test split(String(read(iobuff)), "\n")[2] == "" broken=Sys.iswindows(platform)
+        end
+    end
+
     # This tests only that compilers for all platforms can build a simple C program
     # TODO: for the time being we only test `cc`, eventually we want to run `gcc` and `clang` separately
     @testset "Compilation - $(platform) - $(compiler)" for platform in platforms, compiler in ("cc",)
@@ -347,26 +370,5 @@ end
     end
 end
 
-# Test that we get no warnings when compiling without linking and when building a shared lib with clang
-@testset "Clang - $(platform)" for platform in platforms
-    mktempdir() do dir
-        ur = preferred_runner()(dir; platform=platform)
-        iobuff = IOBuffer()
-        test_c = """
-        int test(void) {
-            return 0;
-        }
-        """
-        test_script = """
-        set -e
-        echo '$(test_c)' > test.c
-        clang -Werror -c test.c
-        clang -Werror -shared test.c -o test.\${dlext}
-        """
-        cmd = `/bin/bash -c "$(test_script)"`
-        @test run(ur, cmd, iobuff; tee_stream=devnull) broken=Sys.iswindows(platform)
-        seekstart(iobuff)
-        @test split(String(read(iobuff)), "\n")[2] == "" broken=Sys.iswindows(platform)
-    end
-end
+
 

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -126,6 +126,7 @@ end
     # Test that we get no warnings when compiling without linking and when building a shared lib with clang
     @testset "Clang - $(platform)" for platform in platforms
         mktempdir() do dir
+            is_broken = platform in [Platform("armv7l", "linux"; libc="musl"), Platform("armv6l", "linux"; libc="musl")]
             ur = preferred_runner()(dir; platform=platform)
             iobuff = IOBuffer()
             test_c = """
@@ -140,10 +141,10 @@ end
             clang -Werror -shared test.c -o test.\${dlext}
             """
             cmd = `/bin/bash -c "$(test_script)"`
-            @test run(ur, cmd, iobuff; tee_stream=devnull) broken=platform in [Platform("armv7l", "linux"; libc="musl"), Platform("armv6l", "linux"; libc="musl")]
+            @test run(ur, cmd, iobuff; tee_stream=devnull) broken=is_broken
             seekstart(iobuff)
             output = String(read(iobuff))
-            @test (occursin("error", output) || occursin("warning", output)) broken=platform in [Platform("armv7l", "linux", "musl"), Platform("armv6l", "linux", "musl")]
+            @test (occursin("error", output) || occursin("warning", output)) broken=is_broken
         end
     end
 

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -143,9 +143,6 @@ end
             """
             cmd = `/bin/bash -c "$(test_script)"`
             @test run(ur, cmd, iobuff; tee_stream=devnull) broken=is_broken
-            seekstart(iobuff)
-            output = String(read(iobuff))
-            @test (occursin("error", output) || occursin("warning", output)) skip=is_broken
         end
     end
 

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -140,10 +140,10 @@ end
             clang -Werror -shared test.c -o test.\${dlext}
             """
             cmd = `/bin/bash -c "$(test_script)"`
-            @test run(ur, cmd, iobuff; tee_stream=devnull) broken=Sys.iswindows(platform)
+            @test run(ur, cmd, iobuff; tee_stream=devnull) broken=platform in [Platform("armv7l", "linux", "musl"), Platform("armv6l", "linux", "musl")]
             seekstart(iobuff)
             output = String(read(iobuff))
-            @test (occursin("error", output) || occursin("warning", output)) broken=Sys.iswindows(platform)
+            @test (occursin("error", output) || occursin("warning", output)) broken=platform in [Platform("armv7l", "linux", "musl"), Platform("armv6l", "linux", "musl")]
         end
     end
 
@@ -370,6 +370,3 @@ end
         end
     end
 end
-
-
-

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -126,7 +126,8 @@ end
     # Test that we get no warnings when compiling without linking and when building a shared lib with clang
     @testset "Clang - $(platform)" for platform in platforms
         mktempdir() do dir
-            is_broken = platform in [Platform("armv7l", "linux"; libc="musl"), Platform("armv6l", "linux"; libc="musl")]
+            is_broken = platform in [Platform("armv7l", "linux"; libc="musl"), Platform("armv6l", "linux"; libc="musl"),#https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/262
+                                     Platform("i686", "windows"), Platform("x86_64", "windows")]#https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/248
             ur = preferred_runner()(dir; platform=platform)
             iobuff = IOBuffer()
             test_c = """
@@ -144,7 +145,7 @@ end
             @test run(ur, cmd, iobuff; tee_stream=devnull) broken=is_broken
             seekstart(iobuff)
             output = String(read(iobuff))
-            @test (occursin("error", output) || occursin("warning", output)) broken=is_broken
+            @test (occursin("error", output) || occursin("warning", output)) skip=is_broken
         end
     end
 

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -364,9 +364,9 @@ end
         clang -Werror -shared test.c -o test.\${dlext}
         """
         cmd = `/bin/bash -c "$(test_script)"`
-        @test run(ur, cmd, iobuff; tee_stream=devnull)
+        @test run(ur, cmd, iobuff; tee_stream=devnull) broken=Sys.iswindows(platform)
         seekstart(iobuff)
-        @test broken=Sys.iswindows(platform) split(String(read(iobuff)), "\n")[2] == "" #TODO: Windows ;-|
+        @test split(String(read(iobuff)), "\n")[2] == "" broken=Sys.iswindows(platform)
     end
 end
 

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -143,7 +143,7 @@ end
             @test run(ur, cmd, iobuff; tee_stream=devnull) broken=Sys.iswindows(platform)
             seekstart(iobuff)
             output = String(read(iobuff))
-            @test ("error" in output || "warning" in output) broken=Sys.iswindows(platform)
+            @test (occursin("error", output) || occursin("warning", output)) broken=Sys.iswindows(platform)
         end
     end
 

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -142,7 +142,8 @@ end
             cmd = `/bin/bash -c "$(test_script)"`
             @test run(ur, cmd, iobuff; tee_stream=devnull) broken=Sys.iswindows(platform)
             seekstart(iobuff)
-            @test split(String(read(iobuff)), "\n")[2] == "" broken=Sys.iswindows(platform)
+            output = String(read(iobuff))
+            @test ("error" in output || "warning" in output) broken=Sys.iswindows(platform)
         end
     end
 


### PR DESCRIPTION
This is to avoid unused argument warnings like in [this build](https://dev.azure.com/JuliaPackaging/Yggdrasil/_build/results?buildId=21607&view=logs&jobId=5850b9b5-9a51-573f-7d03-f1fedbd8a7fb&j=5850b9b5-9a51-573f-7d03-f1fedbd8a7fb&t=34cffb34-e22b-5097-6aba-496cb946d943)