### PR TITLE
Make libstdc++ available at compile time when compiling c++

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -331,6 +331,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
                 # Link with libstdc++ when compiling c++ on non-BSDs
                 "-stdlib=libstdc++"
             ])
+            end
         end
         return flags
     end

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -328,7 +328,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             ])
             if iscxx
                 append!(flags, [
-                # Link with libstdc++ when compiling c++ on non-BSDs
+                    # Link with libstdc++ when compiling c++ on non-BSDs
                     "-stdlib=libstdc++"
             ])
             end

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -329,7 +329,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             if iscxx
                 append!(flags, [
                 # Link with libstdc++ when compiling c++ on non-BSDs
-                "-stdlib=libstdc++"
+                    "-stdlib=libstdc++"
             ])
             end
         end

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -201,6 +201,7 @@ end
             @test run(ur, cmd, iobuff; tee_stream=devnull) broken=is_broken
             seekstart(iobuff)
             # Make sure `iobuff` contains only the input command, no other text
+            is_broken = is_broken || (compiler == "g++" && Sys.isapple(platform) && arch(platform) == "x86_64")
             @test readchomp(iobuff) == string(cmd) broken=is_broken
         end
     end

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -169,6 +169,7 @@ end
             is_broken = compiler == "clang++" && Sys.iswindows(platform)
             ur = preferred_runner()(dir; platform=platform)
             iobuff = IOBuffer()
+            needfpic = Sys.iswindows(platform) ? "" : "-fPIC"
             test_cpp = """
                 #include <complex>
                 std::complex<double> add(std::complex<double> a, std::complex<double> b) {
@@ -190,7 +191,7 @@ end
                 # Build object file
                 $(compiler) -Werror -std=c++11 -c test.cpp -o test.o
                 # Build shared library
-                $(compiler) -Werror -std=c++11 -fPIC -shared test.cpp -o libtest.\${dlext}
+                $(compiler) -Werror -std=c++11 $(needfpic) -shared test.cpp -o libtest.\${dlext}
                 # Build and link program with object file
                 $(compiler) -Werror -std=c++11 -o main main.cpp test.o
                 # Build and link program with shared library

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -188,13 +188,13 @@ end
                 echo '$(test_cpp)' > test.cpp
                 echo '$(main_cpp)' > main.cpp
                 # Build object file
-                $(compiler) -Werror -c test.cpp -o test.o
+                $(compiler) -Werror -std=c++11 -c test.cpp -o test.o
                 # Build shared library
-                $(compiler) -Werror -shared test.cpp -o libtest.\${dlext}
+                $(compiler) -Werror -std=c++11 -shared test.cpp -o libtest.\${dlext}
                 # Build and link program with object file
-                $(compiler) -Werror -o main main.cpp test.o
+                $(compiler) -Werror -std=c++11 -o main main.cpp test.o
                 # Build and link program with shared library
-                $(compiler) -Werror -o main main.cpp -L. -ltest
+                $(compiler) -Werror -std=c++11 -o main main.cpp -L. -ltest
                 """
             cmd = `/bin/bash -c "$(test_script)"`
             @test run(ur, cmd, iobuff; tee_stream=devnull) broken=is_broken

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -162,6 +162,48 @@ end
         end
     end
 
+    # This tests only that compilers for all platforms can build and link simple C++ code
+    @testset "Compilation - $(platform) - $(compiler)" for platform in platforms, compiler in ("c++", "g++", "clang++")
+        mktempdir() do dir
+            # https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/248
+            is_broken = compiler == "clang++" && Sys.iswindows(platform)
+            ur = preferred_runner()(dir; platform=platform)
+            iobuff = IOBuffer()
+            test_cpp = """
+                #include <complex>
+                std::complex<double> add(std::complex<double> a, std::complex<double> b) {
+                    return a + b;
+                }
+                """
+            main_cpp = """
+                #include <complex>
+                std::complex<double> add(std::complex<double> a, std::complex<double> b);
+                int main(void) {
+                    std::complex<double> z3 = add(std::complex<double>(1.,2.),std::complex<double>(4.,2.));
+                    return 0;
+                }
+            """
+            test_script = """
+                set -e
+                echo '$(test_cpp)' > test.cpp
+                echo '$(main_cpp)' > main.cpp
+                # Build object file
+                $(compiler) -Werror -c test.cpp -o test.o
+                # Build shared library
+                $(compiler) -Werror -shared test.cpp -o libtest.\${dlext}
+                # Build and link program with object file
+                $(compiler) -Werror -o main main.cpp test.o
+                # Build and link program with shared library
+                $(compiler)
+                """
+            cmd = `/bin/bash -c "$(test_script)"`
+            @test run(ur, cmd, iobuff; tee_stream=devnull) broken=is_broken
+            seekstart(iobuff)
+            # Make sure `iobuff` contains only the input command, no other text
+            @test readchomp(iobuff) == string(cmd) broken=is_broken
+        end
+    end
+
     # This tests that compilers for all Intel Linux platforms can build simple
     # C, C++, Fortran programs that we can also run
     @testset "Compilation and running" begin

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -190,7 +190,7 @@ end
                 # Build object file
                 $(compiler) -Werror -std=c++11 -c test.cpp -o test.o
                 # Build shared library
-                $(compiler) -Werror -std=c++11 -shared test.cpp -o libtest.\${dlext}
+                $(compiler) -Werror -std=c++11 -fPIC -shared test.cpp -o libtest.\${dlext}
                 # Build and link program with object file
                 $(compiler) -Werror -std=c++11 -o main main.cpp test.o
                 # Build and link program with shared library

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -194,7 +194,7 @@ end
                 # Build and link program with object file
                 $(compiler) -Werror -o main main.cpp test.o
                 # Build and link program with shared library
-                $(compiler)
+                $(compiler) -Werror -o main main.cpp -L. -ltest
                 """
             cmd = `/bin/bash -c "$(test_script)"`
             @test run(ur, cmd, iobuff; tee_stream=devnull) broken=is_broken


### PR DESCRIPTION
This also adds a test similar to the C one but for C++.

Should hopefully fix https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/261#issuecomment-1232268021

I wonder what happens if someone does a cc invocation while linking with the c++ lib. 