### PR TITLE
Make the platform expansions MSAN aware

### DIFF
--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -750,7 +750,7 @@ function expand_gfortran_versions(platform::AbstractPlatform)
     end
 
     if sanitize(platform) == "memory"
-        return platform #MSAN doesn't use libgfortran, it uses libflang
+        return [platform] #MSAN doesn't use libgfortran, it uses libflang
     end
 
     # If this is an platform that has limited GCC support (such as aarch64-apple-darwin),
@@ -796,7 +796,7 @@ function expand_cxxstring_abis(platform::AbstractPlatform; skip=Sys.isbsd)
     if sanitize(platform) == "memory"
         p = deepcopy(platform)
         p["cxxstring_abi"] = "cxx11" #Clang only seems to generate cxx11 abi
-        return p
+        return [p]
     end
                                                                                                                                  
     # Otherwise, generate new versions!

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -750,7 +750,7 @@ function expand_gfortran_versions(platform::AbstractPlatform)
     end
 
     if sanitize(platform) == "memory"
-        return platform #MSAN can't use libgfortran
+        return platform #MSAN doesn't use libgfortran, it uses libflang
     end
 
     # If this is an platform that has limited GCC support (such as aarch64-apple-darwin),

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -749,6 +749,10 @@ function expand_gfortran_versions(platform::AbstractPlatform)
         return [platform]
     end
 
+    if sanitize(platform) == "memory"
+        return platform #MSAN can't use libgfortran
+    end
+
     # If this is an platform that has limited GCC support (such as aarch64-apple-darwin),
     # the libgfortran versions we can expand to are similarly limited.
     local libgfortran_versions
@@ -789,6 +793,12 @@ function expand_cxxstring_abis(platform::AbstractPlatform; skip=Sys.isbsd)
         return [platform]
     end
 
+    if sanitize(platform) == "memory"
+        p = deepcopy(platform)
+        p["cxxstring_abi"] = "cxx11" #Clang only seems to generate cxx11 abi
+        return p
+    end
+                                                                                                                                 
     # Otherwise, generate new versions!
     map(["cxx03", "cxx11"]) do abi
         p = deepcopy(platform)

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -25,6 +25,8 @@ using BinaryBuilderBase
         Platform("x86_64",  "macos"; libgfortran_version=v"5"),
         Platform("aarch64", "macos"; libgfortran_version=v"5"),
     ]
+    @test expand_gfortran_versions([Platform("x86_64", "linux"; sanitize="memory")]) ==
+        [Platform("x86_64", "linux"; sanitize="memory")]
 
     # expand_cxxstring_abis
     @test expand_cxxstring_abis(Platform("x86_64", "linux"; libc="musl")) == [
@@ -48,7 +50,9 @@ using BinaryBuilderBase
     ]
     @test expand_cxxstring_abis([Platform("i686", "linux"; cxxstring_abi="cxx11")]) ==
         [Platform("i686", "linux"; cxxstring_abi="cxx11")]
-
+    @test expand_cxxstring_abis([Platform("x86_64", "linux"; sanitize="memory")]) ==
+        [Platform("x86_64", "linux"; sanitize="memory", cxxstring_abi="cxx11")]
+    
     # expand_microarchitectures
     @test expand_microarchitectures([AnyPlatform()]) == [AnyPlatform()]
     @test sort(expand_microarchitectures(Platform("x86_64", "linux"; cuda="10.1")), by=triplet) == [


### PR DESCRIPTION
How about this, so then we don't get useless builds, but still have the tags when needed