### PR TITLE
Enforce type stability and test for it

### DIFF
--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -769,8 +769,8 @@ function expand_gfortran_versions(platform::AbstractPlatform)
         return p
     end
 end
-function expand_gfortran_versions(ps::Vector{<:Platform})
-    return collect(Iterators.flatten(expand_gfortran_versions.(ps)))
+function expand_gfortran_versions(ps::Vector{T}) where {T<:AbstractPlatform}
+    return collect(T,Iterators.flatten(expand_gfortran_versions.(ps)))
 end
 
 """
@@ -806,8 +806,8 @@ function expand_cxxstring_abis(platform::AbstractPlatform; skip=Sys.isbsd)
         return p
     end
 end
-function expand_cxxstring_abis(ps::Vector{<:AbstractPlatform}; kwargs...)
-    return collect(Iterators.flatten(expand_cxxstring_abis.(ps; kwargs...)))
+function expand_cxxstring_abis(ps::Vector{T}; kwargs...) where {T<:AbstractPlatform}
+    return collect(T,Iterators.flatten(expand_cxxstring_abis.(ps; kwargs...)))
 end
 
 """

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -27,7 +27,7 @@ using BinaryBuilderBase
     ]
     @test expand_gfortran_versions([Platform("x86_64", "linux"; sanitize="memory")]) ==
         [Platform("x86_64", "linux"; sanitize="memory")]
-    @test expand_gfortran_versions(Platform[]) isa Platform[]
+    @test expand_gfortran_versions(Platform[]) isa Vector{Platform}
 
     # expand_cxxstring_abis
     @test expand_cxxstring_abis(Platform("x86_64", "linux"; libc="musl")) == [
@@ -53,7 +53,7 @@ using BinaryBuilderBase
         [Platform("i686", "linux"; cxxstring_abi="cxx11")]
     @test expand_cxxstring_abis([Platform("x86_64", "linux"; sanitize="memory")]) ==
         [Platform("x86_64", "linux"; sanitize="memory", cxxstring_abi="cxx11")]
-    @test expand_cxxstring_abis(Platform[]) isa Platform[]
+    @test expand_cxxstring_abis(Platform[]) isa Vector{Platform}
 
     # expand_microarchitectures
     @test expand_microarchitectures([AnyPlatform()]) == [AnyPlatform()]

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -27,7 +27,7 @@ using BinaryBuilderBase
     ]
     @test expand_gfortran_versions([Platform("x86_64", "linux"; sanitize="memory")]) ==
         [Platform("x86_64", "linux"; sanitize="memory")]
-    @test expand_gfortran_versions(Platform[]) == Platform[]
+    @test expand_gfortran_versions(Platform[]) isa Platform[]
 
     # expand_cxxstring_abis
     @test expand_cxxstring_abis(Platform("x86_64", "linux"; libc="musl")) == [
@@ -53,7 +53,7 @@ using BinaryBuilderBase
         [Platform("i686", "linux"; cxxstring_abi="cxx11")]
     @test expand_cxxstring_abis([Platform("x86_64", "linux"; sanitize="memory")]) ==
         [Platform("x86_64", "linux"; sanitize="memory", cxxstring_abi="cxx11")]
-    @test expand_cxxstring_abis(Platform[]) == Platform[]
+    @test expand_cxxstring_abis(Platform[]) isa Platform[]
 
     # expand_microarchitectures
     @test expand_microarchitectures([AnyPlatform()]) == [AnyPlatform()]

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -27,6 +27,7 @@ using BinaryBuilderBase
     ]
     @test expand_gfortran_versions([Platform("x86_64", "linux"; sanitize="memory")]) ==
         [Platform("x86_64", "linux"; sanitize="memory")]
+    @test expand_gfortran_versions(Platform[]) == Platform[]
 
     # expand_cxxstring_abis
     @test expand_cxxstring_abis(Platform("x86_64", "linux"; libc="musl")) == [
@@ -52,7 +53,8 @@ using BinaryBuilderBase
         [Platform("i686", "linux"; cxxstring_abi="cxx11")]
     @test expand_cxxstring_abis([Platform("x86_64", "linux"; sanitize="memory")]) ==
         [Platform("x86_64", "linux"; sanitize="memory", cxxstring_abi="cxx11")]
-    
+    @test expand_cxxstring_abis(Platform[]) == Platform[]
+
     # expand_microarchitectures
     @test expand_microarchitectures([AnyPlatform()]) == [AnyPlatform()]
     @test sort(expand_microarchitectures(Platform("x86_64", "linux"; cuda="10.1")), by=triplet) == [


### PR DESCRIPTION
#271 made `expand_cxxstring_abis` type unstable, so force specialization on it.