### PR TITLE
[Sources] Consider URLs starting with `git://` as Git repositories

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.18.0"
+version = "1.18.1"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/Sources.jl
+++ b/src/Sources.jl
@@ -98,6 +98,9 @@ end
 DirectorySource(path::String; target::String = "", follow_symlinks::Bool=false) =
     DirectorySource(path, target, follow_symlinks)
 
+# Try to guess if a URL is a Git repository
+isgitrepo(url::AbstractString) = endswith(url, ".git") || startswith(url, "git://")
+
 # This is not meant to be used as source in the `build_tarballs.jl` scripts but
 # only to set up the source in the workspace.
 struct SetupSource{T<:AbstractSource}
@@ -112,7 +115,7 @@ SetupSource{T}(path::String, hash::String, target::String) where {T} =
 # This is used in wizard/obtain_source.jl to automatically guess the parameter
 # of SetupSource from the URL
 function SetupSource(url::String, path::String, hash::String, target::String)
-    if endswith(url, ".git")
+    if isgitrepo(url)
         return SetupSource{GitSource}(path, hash, target)
     elseif any(endswith(path, ext) for ext in archive_extensions)
         return SetupSource{ArchiveSource}(path, hash, target)

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -14,6 +14,7 @@ using JSON
     @test SetupSource("https://ftp.gnu.org/gnu/wget/wget-1.20.3.tar.gz", "wget-1.20.3.tar.gz", "", "") isa SetupSource{ArchiveSource}
     @test SetupSource("https://ftp.gnu.org/gnu/wget/wget-1.20.3.zip", "wget-1.20.3.zip", "", "")    isa SetupSource{ArchiveSource}
     @test SetupSource("https://github.com/jedisct1/libsodium.git", "libsodium.git", "", "")       isa SetupSource{GitSource}
+    @test SetupSource("git://developer.intra2net.com/libftdi", "libftdi", "", "") isa SetupSource{GitSource}
     @test SetupSource("https://curl.haxx.se/ca/cacert-2020-01-01.pem", "cacert-2020-01-01.pem", "", "")   isa SetupSource{FileSource}
 
     @testset "Download and setup" begin


### PR DESCRIPTION
Basically same as https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/940, but in this package.  Fix bug reported by @Seelengrab on Slack.