### PR TITLE
Add newer builds of Rust toolchain to `Artifacts.toml`

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -3254,6 +3254,94 @@ os = "linux"
     sha256 = "1be3e42fd7471f475aa7f042c8e719457dbbce780d31a46da25bdc2cc762b978"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.61.0/RustBase.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustBase.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "212379f60865ca7fbe72f84b6beda04521b17aae"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustBase.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "f166e7ac2a269fca901f1bdaa7e906d9edba6b3502bd818a00d614c456c9ad03"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.62.1/RustBase.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustBase.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "b942d5af5c0f3fc52f1e6fc7967fb115c5c9387e"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustBase.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "d4c5e1fa2d4b2613b707c2123195411f93e723866de48f1b7c3db03c247473ef"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.62.1/RustBase.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustBase.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "47c1dc60408ff98d0176b783c6bc05170e98813d"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustBase.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "f6f219ce3e8cdf39cd2b1d82da082c45ca386c78b7434a34377816fa84373dec"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.63.0/RustBase.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustBase.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "fbc82862d54b7121f53754bdc72316a62c8a1007"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustBase.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "b52e7bed4fedcae78a26272ca8ecd8d1030fad85a91dff88868ec79f86ba016f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.63.0/RustBase.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustBase.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "ccd04389ff159cffdbc1cf9822101ae483f2fc09"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustBase.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "4e94d777b1bf0fd5959fae0284c12450b79ea9a893b29a4d20b3b3357de4afaf"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.64.0/RustBase.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustBase.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "a6361ff04b05838829ac1d0ad095876509a6d8c7"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustBase.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "6a2680fa19a35f0d448426cc153b16681eaac8bdb37ac99357a83928c8d3c9cd"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.64.0/RustBase.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustBase.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "dac38317c5687f5fa8bcfa6eb9a3971b5b92dd07"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustBase.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "5726a559fd9f00f7bf70db329ed8b454694267b9dd4efd9d8c0817218c59992a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.65.0/RustBase.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustBase.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "8698f56f764dfa94994a11349c08f3bd24de9066"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustBase.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "08209bd2fb96b5ed5356095c93abe42884cdccd32684538aa48e3d0c3bb72288"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustBase-v1.65.0/RustBase.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-aarch64-apple-darwin.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "f12052bec0cfb5df95d3c7dd7ae0be0594eed0fb"
@@ -3319,6 +3407,94 @@ os = "linux"
     [["RustToolchain-aarch64-apple-darwin.v1.61.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "4ff9ce4568ed0eda95036af39835084cf6537f105fadf5ce7415187be347aa89"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-aarch64-apple-darwin.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-apple-darwin.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "1b68815a49ba229666e9b9e780255c47c3999bdb"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-apple-darwin.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "cd844db1fb815aa1e5048fad1f73d6cd5108f130a327d2b68c508cc8be670dc5"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-aarch64-apple-darwin.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-apple-darwin.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "ea4be91e96aea83d5214abb28032a676cfdd8fee"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-apple-darwin.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "8bb703c174c33189e36666d42252c893073ed2714daba41a5978e6c949ccfb49"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-aarch64-apple-darwin.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-apple-darwin.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "d8270dcb000453dca9626d8eedb825a9459b6936"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-apple-darwin.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "5e4c36eadaffdfac7ca255aa9b57fcdbdbdc9a4d524b547b42b6e9ce886cc923"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-aarch64-apple-darwin.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-apple-darwin.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "d85688a384015d7addab818c803762c9b3127262"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-apple-darwin.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "5ebc5901ec3b6b5e8a7f60500049afbc31ef67d713fb16caae8cf73df1203289"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-aarch64-apple-darwin.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-apple-darwin.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "b24b2418d80a98d22bcbbc7c9ca4c9a3120d8b77"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-apple-darwin.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "72f2c047bfad2dce96839a3f189f080e4fb6cb6f5a9e4e7f05bc554e5085cb7b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-aarch64-apple-darwin.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-apple-darwin.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "ffc19d2a93b3577f3511e3c674f84b570cf47c51"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-apple-darwin.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "c35d7d3df33b0d5f321f911b204fbf6424b3f37f3aa5631b6c869f71f5b3a5d8"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-aarch64-apple-darwin.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-apple-darwin.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "c9cdea710d5bcb5112f7a83260b18a5402e1a626"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-apple-darwin.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "d305bb4c5605f246d9950381975ea4de8faadaaf9127d085e8c29d82d9ded7de"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-aarch64-apple-darwin.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-apple-darwin.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "89514a5705cca8f71b6a40b201fd90e18d21b512"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-apple-darwin.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "836bad48b186a2fc1e60cfa674e3a1abae2f93d0d0c592a8800d134d6273e9f4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-aarch64-apple-darwin.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-aarch64-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -3386,6 +3562,94 @@ os = "linux"
     sha256 = "d2b56191b6bed7b31740e67c2fec2f1154a73ef88d77b090cf85d392bdf7db80"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-aarch64-linux-gnu.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-aarch64-linux-gnu.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "9108f907fa01b538a2b3b23d73668d5fa1a9d0a7"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-gnu.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "42d121da9e9bc27a280b3f64225a0c0097729ece13e5b7bf349f5f173738e1b5"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-aarch64-linux-gnu.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-linux-gnu.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "2fd064370d60f5c2914cb8efcf2ad06604d27137"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-gnu.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "989f2ef82026ea589ae420ae81afab6631dc6673b2cf8fbe5ae9e5a1afa731c8"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-aarch64-linux-gnu.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-linux-gnu.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "46c758fecf640f150065e7cba510a4508beb18fa"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-gnu.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "4febd1d80284a6a0253f89bcbc8369c3cd9f7c93f3610f476b6e7b2a579a600b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-aarch64-linux-gnu.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-linux-gnu.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "3e705f660c2d2548c20798b14aca1c2fc455a0b2"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-gnu.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "12d452fccb8e0367c1a78edbe9ca11ee08b6a9e92efc333d7fb07c4dea4930a9"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-aarch64-linux-gnu.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-linux-gnu.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "8dc324fbe5ad3c43d5d40fae4d6b5d0450f118a8"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-gnu.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "10da29f954af7e8ac9ab5efead745c2022fcabb2ac397e7c0c53749a8f2de064"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-aarch64-linux-gnu.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-linux-gnu.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "454be57fc5882be671d63af9e54a8b40043c56c0"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-gnu.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "06a0f25fa353188d57aae34f1d7547a839db9d31ff931b85dec842c9e5184626"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-aarch64-linux-gnu.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-linux-gnu.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "5664af410472f763300b1815973a352536814d2c"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-gnu.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "1d2d03e3676266dca2ab4119093d9d58fedafde1af8501c49ff2f1ab50a93d90"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-aarch64-linux-gnu.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-linux-gnu.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "26d23c46454c775ea5a383320d9a0078dec82696"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-gnu.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "0be3cbb55a3deee22d3d703b3570ac31c217bb800c081d4e50f1c2c995334141"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-aarch64-linux-gnu.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-aarch64-linux-musl.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "810db8e4711de59c9bf7468377bc08dcb8a56a2b"
@@ -3451,6 +3715,94 @@ os = "linux"
     [["RustToolchain-aarch64-linux-musl.v1.61.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "bd78e6a8d1d7f769422cad2fb6c82b39281de39f7ac1f173b4fae458236220a1"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-aarch64-linux-musl.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-linux-musl.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "50ccc1e52334a0573ebe7980e516133ca8c8bd5c"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-musl.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "bcc94da44d11babbc31602c3d43c81adc52989ad8090627d8496dca15737453f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-aarch64-linux-musl.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-linux-musl.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "26df576a2386e974407cd950217c44139adb7121"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-musl.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "6857ffb3392f80f2260466bc01712613fd7b6feff3821ef70a758ecfa77dbabd"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-aarch64-linux-musl.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-linux-musl.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "1aafbe433e010ffa0b27ad75120c3a86ba2a5531"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-musl.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "ba020608b9e8040a1244923952a2ad74ce110e369a9e929beeca4ce2bbf43c52"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-aarch64-linux-musl.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-linux-musl.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "84c845f2ccd89d4826c7e0bc7e282c0d1cd18c20"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-musl.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "16e09029578cf6216d7e6dbf54883e3e6532c3390b9f4684dcbc2463ff81eacc"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-aarch64-linux-musl.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-linux-musl.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "a00d234d67cc01e5368cb0aaf2d79d4ac0062550"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-musl.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "2d820bd9e721cbb81a5a04a78983447898e50608cb31eb4680c1e99432123700"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-aarch64-linux-musl.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-linux-musl.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "1b7f0b2069f7a783f60778033f331a3000942507"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-musl.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "c968921b13cb205820965174f475148bcb32427dd8b704a2df518cc22fd439e4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-aarch64-linux-musl.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-aarch64-linux-musl.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "09dd8ac7356ac6c0df5edfc51be338e7b4fdd393"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-musl.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "f21ca979d6154758bc47d7df67233d9c8832301057f3894f95271f0791ccbb14"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-aarch64-linux-musl.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-aarch64-linux-musl.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "1d2edeca671a5ac226758a5a50d51bdf23fcf5d9"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-aarch64-linux-musl.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "25d9718a96dc38662e15b743e7b1ad23f34429fe98dd704e29248c2dcebbc988"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-aarch64-linux-musl.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-armv6l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -3518,6 +3870,94 @@ os = "linux"
     sha256 = "6ff550914cd86917cf141e04fbc4b775395a13d7cd9dc643d9a6c0b670e9c581"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-armv6l-linux-gnueabihf.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-armv6l-linux-gnueabihf.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "c29a496d13e3720bab8d7735319c24de0e04eb71"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-gnueabihf.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "ecff6055cae5ac407684c3f815e6f598a9534782c7e6611c4faf422e47ab0ad7"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-armv6l-linux-gnueabihf.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv6l-linux-gnueabihf.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "345afdd81dc472c795cbea11e7b6ae3d04718168"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-gnueabihf.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "b0fda99977feffd78fb5e1fa3699f45ab6cd7dba083d4da4a812d8a7b54ee924"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-armv6l-linux-gnueabihf.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv6l-linux-gnueabihf.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "7e2628e70127015558966c4f300cd201ba70af91"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-gnueabihf.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "e29e876e11216968aa0892b4f98637a9935fdd81007878742637707c2907a065"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-armv6l-linux-gnueabihf.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv6l-linux-gnueabihf.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "96d1131798948635cd9786b97aad84035345c2af"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-gnueabihf.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "2c45b88b8e1c3a641f86567b29b1e77c5efea5eee9c527917f2201e2b1c82e60"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-armv6l-linux-gnueabihf.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv6l-linux-gnueabihf.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "0122976112581d0138d2d48ea4344d8418cfeddb"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-gnueabihf.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "f18dda6c0a3b3997125057db928edad38a7ff934d8d048e0406bea3bcd48d599"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-armv6l-linux-gnueabihf.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv6l-linux-gnueabihf.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "ecfa9e3241ef8e50d809811e7ec3ee6d6f40cea0"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-gnueabihf.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "164fb174e6bc83c3a63e12d6e1a2bcadfde57e5c3d9314380d6e90650f0747e7"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-armv6l-linux-gnueabihf.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv6l-linux-gnueabihf.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "eb494a1c89d87e52a767f92c741de2e44c0c9da5"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-gnueabihf.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "fa6985d5fa19714dcf94b3161b49bc8c583a051160578caf3d9f5679ac88f8e6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-armv6l-linux-gnueabihf.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv6l-linux-gnueabihf.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "49c58f46973c8386681cda0f212a511989b827b7"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-gnueabihf.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "3b39343c9ff977ae96ad5e96554c5536f3ca316620e3930dbaa865fc341905a3"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-armv6l-linux-gnueabihf.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-armv6l-linux-musleabihf.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "5fe0c670498b95d38bd4c04e571e5d333c5600e0"
@@ -3583,6 +4023,94 @@ os = "linux"
     [["RustToolchain-armv6l-linux-musleabihf.v1.61.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "2b3f8fd44f53f5247caab47a92602cb9e377911b599c9e297061730a72fc141e"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-armv6l-linux-musleabihf.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv6l-linux-musleabihf.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "a8c6ea1d7b6c7cea659cc4ea829a6e6d86dfbadf"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-musleabihf.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "2ea265872b710f9869fd18336e2a9c73d1f105af5c411aad7d8b8503aa0e6dfe"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-armv6l-linux-musleabihf.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv6l-linux-musleabihf.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "33da3642e7aa032af936f4f77e03cac4f7e8b522"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-musleabihf.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "7adcfc010b7e3f8c969885c228c793592c6941213c9c53c72f1ea4c52cfb8882"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-armv6l-linux-musleabihf.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv6l-linux-musleabihf.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "2145f62180504aac0dc43d599a3ced13b08cfcc4"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-musleabihf.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "33b814e7a96b947e98d51552511cc226e156302d5ebc72c8a772aef016a56e48"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-armv6l-linux-musleabihf.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv6l-linux-musleabihf.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "ab0bbaacb3cd7cc71192ac709e25f0a29c2d7b2f"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-musleabihf.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "c716ebadbccd6003bdb0a0ea99f0cd3eefe0cc7b75d7621cfe091da574725897"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-armv6l-linux-musleabihf.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv6l-linux-musleabihf.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "f4b76b5d9f173a7c6b3841e00281c20d41baf923"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-musleabihf.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "a7fd3d2079b2e04072531da1184b72489178990b3f1bd0d5769832e2f91ff6ff"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-armv6l-linux-musleabihf.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv6l-linux-musleabihf.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "795582898a410955ad401064753a352e37b12b30"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-musleabihf.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "3f4d525e07fb78854f6fbd798898ffc5c58d1b9435090faef062bdf059b376b2"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-armv6l-linux-musleabihf.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv6l-linux-musleabihf.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "95f13b589643167aca4a22a5b8680a1fb7b3d189"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-musleabihf.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "cb068b26941e063152377f2b476208d82522c5ef19dfdfe8d094e66ce68ac873"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-armv6l-linux-musleabihf.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv6l-linux-musleabihf.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "23b28c7c4639d8d6bf551d58b9821abf69226666"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv6l-linux-musleabihf.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "13605779b6cb8e9efc7ef533f33043df90c4079b24a96902a3578f0b901c0c16"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-armv6l-linux-musleabihf.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-armv7l-linux-gnueabihf.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -3650,6 +4178,94 @@ os = "linux"
     sha256 = "bf85b2be94514973ad6d9b36a5021ee805b6b83f848af5166ff779001183f3c5"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-armv7l-linux-gnueabihf.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-armv7l-linux-gnueabihf.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "7b7d3c890547a03b5bd93b64f6a3ba8fe86cca1c"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "7465429de5b2325ba431a18d1651bdd4abf4a99d94a1ecfc2482c1e6cd03051b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-armv7l-linux-gnueabihf.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv7l-linux-gnueabihf.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "93cb9b1b27714fa88091a8c2185c482539d8b30b"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "c1ab00d8858cee7368d201519a1e94430c6ebf539da1cc20005e69373ea1d896"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-armv7l-linux-gnueabihf.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv7l-linux-gnueabihf.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "0264ad3b79cec965ee13b7c09e0509f582ed18ae"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "afe21cb54d178aa0ad8067c6d57482890316cddd9676e415f6f6e12c5aab357c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-armv7l-linux-gnueabihf.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv7l-linux-gnueabihf.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "bd7c1a9557eb8355e93d28f6d00195d95fe2a98c"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "c52c4175384c20d4632a44883b46bd210422430add902855e3ecf0e5f9426126"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-armv7l-linux-gnueabihf.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv7l-linux-gnueabihf.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "0b6a0a897c159820d85862e45fad549b7bf5439f"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "f3e9508a61c1649b587bcb7f66bbcd2009f734b872451ce68e5907824b388d39"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-armv7l-linux-gnueabihf.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv7l-linux-gnueabihf.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "3973bde0401e7e718b7d8af2616482875aff4bb9"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "667874743ae6e8e77a52d9ab1f87ee4181337d771b6944ccb4eb0c76f80a2155"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-armv7l-linux-gnueabihf.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv7l-linux-gnueabihf.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "f010bcdb556e9cf48088d175a8cc8dbc3f24ea43"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "4d0480641de7f7c8743601e19fab1761906e7e50905ed9a484195a7a68cbed74"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-armv7l-linux-gnueabihf.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv7l-linux-gnueabihf.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "6b2a34959ad1df9c3e67b9532ce425dba038348f"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-gnueabihf.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "e9cc552a600823b56136d784cf044c1206f8b355b56a220b1ed8d5db98cb75b3"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-armv7l-linux-gnueabihf.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-armv7l-linux-musleabihf.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "4cbc067a6fc0365568a5665d97f50759b5e5ce30"
@@ -3715,6 +4331,94 @@ os = "linux"
     [["RustToolchain-armv7l-linux-musleabihf.v1.61.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "94fab29511cc91a41a06bc57a35c0d106ec5933a05673a7a8dc3fb52b961b508"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-armv7l-linux-musleabihf.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv7l-linux-musleabihf.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "0aeaa3df048d7f1fadaa972e60196c4adbc43ecf"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-musleabihf.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "623669ef8689edc2ad370a49368ec40ee448a15927cf441627227ea83fd2892f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-armv7l-linux-musleabihf.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv7l-linux-musleabihf.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "8f6d519889df42808aef783d3ae4c021d3910c6d"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-musleabihf.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "2535b885ec9a216c9d7abdf8a0d4ea97b8331898746d8b974c6ba33149da3545"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-armv7l-linux-musleabihf.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv7l-linux-musleabihf.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "b83c4fd82e3e8b5bb991a7b1c7a0105d25053614"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-musleabihf.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "4921a512005e1d1563721ebf517881465a241755fb2669ce6f94ae8f89918b7f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-armv7l-linux-musleabihf.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv7l-linux-musleabihf.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "55f81d8454b5b5af5bb1f075d1cccfa222e725b3"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-musleabihf.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "f6ec040dfd95fe8c2ebbe904fdc2fbf33e18eddc2b1be5ed7355d7d183d29c6b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-armv7l-linux-musleabihf.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv7l-linux-musleabihf.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "51688bc9ee6ac21a0456e208f99db44087e51e8f"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-musleabihf.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "24af3b1b5ba75a5792616ec3bce97b13a2c9ce2b48f60ef122d8e03580ab5ab6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-armv7l-linux-musleabihf.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv7l-linux-musleabihf.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "3ad8c7f8c3a09fa9c57daa5652468c4119b0510e"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-musleabihf.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "5ace9b55e0ac97b138a0b42b980a95d007786d85375585363553565e67356aae"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-armv7l-linux-musleabihf.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-armv7l-linux-musleabihf.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "27f2e952ae68c5ed46b86169387e4df9e95f61f7"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-musleabihf.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "f3cfe79283dc7f3619b3b7e28f1775884de6136f997408a67a81091af69b050c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-armv7l-linux-musleabihf.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-armv7l-linux-musleabihf.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "6e6d0f25fbd7be5f4662f62f3157bc411b0cd3d2"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-armv7l-linux-musleabihf.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "7eb9b1806c6d31ddc8c1864db9ed2cdccbafd259b439a40c4e74833271044423"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-armv7l-linux-musleabihf.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-i686-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -3782,6 +4486,94 @@ os = "linux"
     sha256 = "1c9b61d9a822abdabbfedfda80bd4ac3f925ca6bfacc5523cca659aed5db9d31"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-i686-linux-gnu.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-i686-linux-gnu.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "0c0d16c52c765b8956727219ff5bc65ba43a1053"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-gnu.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "6725a6f20a596003c3cce21abb1edbb6ec8587ca00d33f8aa8d5f14a5ce328aa"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-i686-linux-gnu.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-linux-gnu.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "592ac62272e32b8f4fb726ae1189be84db8a6b4f"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-gnu.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "d292209180b5e494064d243b0a818613a3136b9d0330d850e9fee27ace2324f6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-i686-linux-gnu.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-i686-linux-gnu.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "6c9d047d1d7616875ace003f54741a62c654f328"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-gnu.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "594f72a0cafb80a68b6bf757e433778d3640ba4051bd9689cb2eb533bf8ad6e2"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-i686-linux-gnu.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-linux-gnu.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "28ffc145527eec02f019cceb817467196bf24b60"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-gnu.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "26db613619d771ceb7a19e2e888173a135166dc332f536750051fd56b94bf638"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-i686-linux-gnu.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-i686-linux-gnu.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "fafe3dbc60b75fd784d1a84acb3f5f9f72027ca3"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-gnu.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "4e7f0dbbb5092ef24a3c892ad29c280a7548afb630f3311fc4158904d7b5eb0d"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-i686-linux-gnu.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-linux-gnu.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "d5dc232314e4ad457b4b880506862bef4f526ce3"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-gnu.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "52e338156e329effcf6da298261201116b59e4ba4a44da59598a23edbb4d80b4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-i686-linux-gnu.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-i686-linux-gnu.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "ee6ea43f52c7e54c1e851d7909d22ce9cb9be8ed"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-gnu.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "66825e00009804d0c15b409b446978a7459c2a925f396941fad2b10d8c387b98"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-i686-linux-gnu.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-linux-gnu.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "7ca983ba53b00d165296a4d5c1624316033bfdec"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-gnu.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "f311e79568220feebd33462724db976eab647eaf2b8365d266925fa1788c960a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-i686-linux-gnu.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-i686-linux-musl.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "a744cffb841c02b6a8fc46d9a1e7990f27db62da"
@@ -3847,6 +4639,94 @@ os = "linux"
     [["RustToolchain-i686-linux-musl.v1.61.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "1335f502ba4783b301faaa427aba0b184ae1125669be249b6a0a7b7c51a41e91"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-i686-linux-musl.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-i686-linux-musl.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "8ee3891092c68ce761c3d99262c55ae78a527a9e"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-musl.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "f14d75e3ecd861ad9b4a90021de1962b6b11ba60c72d6e3a4b360082bf985e7f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-i686-linux-musl.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-linux-musl.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "5859540fb1dbf6c4dc63ee0c612bbf0148871f77"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-musl.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "e6536289c2feac1ea10fbab6ca1532990ee21d3f89b7db68351cfaabf9510de0"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-i686-linux-musl.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-i686-linux-musl.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "ffe1d80ad3433d2f8b1b35f0ce43ea8d1195aa8f"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-musl.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "69b4625fa9bfb2d00ac9a381812f5d1152a4166347894eabe8e6e38d674b8593"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-i686-linux-musl.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-linux-musl.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "51d5de46f4a3316eb1d0f88013600b63bacafe2d"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-musl.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "855b9d294293ab6721cbe04cb265a5b00a5b5f6371233f792cd83707c15a8ce0"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-i686-linux-musl.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-i686-linux-musl.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "0aab02d05394c2f46b99fe6c776e3664221abf86"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-musl.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "a69b8920461addf20c76dea6962a3a623a9df623149d6d7cf03addac418d5512"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-i686-linux-musl.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-linux-musl.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "9ee9ca35c6713c77ee89f7ea40b5bc21f0ace5bc"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-musl.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "e18a145c65729a2c5f75238928ffbbfb6b4e523123e635190131471034f59d3a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-i686-linux-musl.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-i686-linux-musl.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "4a39faa59c1bed419a4e5fecdc76da3d21d65d3e"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-musl.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "aa30dfa499266600dc0267c97df0b0519e4dd0cd56a66f84d70dcd5ad70bcdcb"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-i686-linux-musl.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-linux-musl.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "29c115f2ba8c294ed488df65027384eace3ad277"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-linux-musl.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "8cc8c1b8c85ea89b350a85deb54c155bbad448fe9478730a6a1476313f3d9a6b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-i686-linux-musl.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-i686-w64-mingw32.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -3914,6 +4794,94 @@ os = "linux"
     sha256 = "02995aa9fcb5aeadbcb04d77b7194804dc66e6ead3d35bbde7f180b68d221393"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-i686-w64-mingw32.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-i686-w64-mingw32.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "00f657639359edd0d0e7e4bb556ee2c22f9a3cee"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-w64-mingw32.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "95f064c2d9910e4c77554cb69b96639e11ee9c89794d060d5504171b4df4d098"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-i686-w64-mingw32.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-w64-mingw32.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "3987ac6887668db5e331f922e706fdf1f8c29944"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-w64-mingw32.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "60bf553c14f245131fc599bdc235bd1e854f70e37dfbe17302f4eacad57d34ae"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-i686-w64-mingw32.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-i686-w64-mingw32.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "c7c6dffbf0ded9850e07ad5e57298cdd91451c92"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-w64-mingw32.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "49a2d2ec1e7ffd02c8a19a277c4c64358ff1444019eebd94fdb7a236a13a813a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-i686-w64-mingw32.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-w64-mingw32.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "dca081d5879d68b4ed2196aa2f498aeea9ca0215"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-w64-mingw32.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "605ecc44cb018688d41a9a87ec8c42459a8b3cba0592fe873b54f9d18b76e68b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-i686-w64-mingw32.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-i686-w64-mingw32.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "10e6ad168481cb217bbbb6fd279947746b9bda95"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-w64-mingw32.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "13125e3dd96d5ca5f3b44bbd3aa173b226934add7bb71bc969acec3f8f351b66"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-i686-w64-mingw32.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-w64-mingw32.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "565447b4782be0af09bcd6b4459825e3e70b83ae"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-w64-mingw32.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "39350aa6de53b222da77f299677deaa4e69a21dcfa6f2e9cba53c42462436b93"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-i686-w64-mingw32.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-i686-w64-mingw32.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "90c06a02e9aa2f6061fb21117a7205a6f5565b47"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-w64-mingw32.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "b48a8dba52e8c154b96c0d0088f44073a4f972602669a420fa00a6edc77a4aa6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-i686-w64-mingw32.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-i686-w64-mingw32.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "45ac9d1b7865e93ce9b5e0d376158e01df1560c1"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-i686-w64-mingw32.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "1975bb140423e4f2d47efbbaeb7546f665d78e65eb433d2dd344a48e502a36c0"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-i686-w64-mingw32.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-powerpc64le-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "e4b8afc31d9d30ad7bce739724965a96a580c023"
@@ -3979,6 +4947,94 @@ os = "linux"
     [["RustToolchain-powerpc64le-linux-gnu.v1.61.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "fbbcead0d14e835dd8d8dffaeb5ccccb2d2b7da3c323bc9c3e050fdde4d7ae6b"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-powerpc64le-linux-gnu.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-powerpc64le-linux-gnu.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "9ce86f6776150e405d6be3e86555652a4cabb851"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-powerpc64le-linux-gnu.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "2e64a38dc7106c7d0a45a70c1a833791b42605904c1feff12ab00d05e9d05953"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-powerpc64le-linux-gnu.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-powerpc64le-linux-gnu.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "a68795ab9f99123275672bd6b0f1f71e9a74a4d6"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-powerpc64le-linux-gnu.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "b3b02c960e20e098ea3b11489a7c5348a93b0ce975f4d428ca53d64206bb45e5"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-powerpc64le-linux-gnu.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-powerpc64le-linux-gnu.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "23429074a5dea9cc220ae4978f7464e34517b985"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-powerpc64le-linux-gnu.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "0ad960c269609e591972c9afd7e6cd4c2ec971584802c415d0dbc3990b58c23d"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-powerpc64le-linux-gnu.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-powerpc64le-linux-gnu.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "fa46c1f97f196b9b0402b4985b43a890e169a56e"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-powerpc64le-linux-gnu.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "fb3a84091cd891e4baec8e34fb57c7ed86387e842620813aeb77a52b392219dc"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-powerpc64le-linux-gnu.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-powerpc64le-linux-gnu.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "9727aa90ee3b58be7d5ca57cca6e18b8131da58a"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-powerpc64le-linux-gnu.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "4e566e52e3bf7adacbd7f7a949a36b0904d798a28e76a1ffa948e06a3b05b9e2"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-powerpc64le-linux-gnu.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-powerpc64le-linux-gnu.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "f7ce3d21daaac61d42f0b07c2e2fab4a920aa76b"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-powerpc64le-linux-gnu.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "d57a225c8468caa3279c5aa9a32b4c6d3e5bda517c1b8e7118d9c8d6bd17cc35"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-powerpc64le-linux-gnu.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-powerpc64le-linux-gnu.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "5000d0977145e838cf1173ab31f1fa43dbb16665"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-powerpc64le-linux-gnu.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "e0f040ed594085f0d0f1ae10b5c1529fbaa5a04b478a4d85f1fe5a5d1d6e9a91"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-powerpc64le-linux-gnu.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-powerpc64le-linux-gnu.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "1d4f9efb7451c6e3c9c31759c7ec77fc3048ef4e"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-powerpc64le-linux-gnu.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "4f06806cc20212eb104db5ee36ec6abd32db0d64df8cf947463de2245ae6ef54"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-powerpc64le-linux-gnu.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-x86_64-apple-darwin.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -4046,6 +5102,94 @@ os = "linux"
     sha256 = "eeb5e7db12cf1a1d29ab0e5a27abdb34624664a402cfc7cf515907372d194fbc"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-x86_64-apple-darwin.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-x86_64-apple-darwin.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "43c0144c500ef84a69551f5926e5846e488bcfb5"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-apple-darwin.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "ed5624a9799fbe3ba08a4995f1717a13437ee84078ceb6429a527283785d5b06"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-x86_64-apple-darwin.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-apple-darwin.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "7257005017a0e6acbf7be7c31a642ac04096d274"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-apple-darwin.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "48e3a176a571591bb1f36a19699c58a7fec6a0dac2d13eeaff4d571b6bcabe62"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-x86_64-apple-darwin.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-apple-darwin.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "8b4249f4580ef80fd2779ec1e8e05c67e8901f16"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-apple-darwin.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "d3397ce15e0c32aa09a79b0251696212c1f6e2312f9c5b19a9248a54607b10fe"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-x86_64-apple-darwin.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-apple-darwin.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "e85388ea6c21190e6b9905bd6da5087bc0b9177b"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-apple-darwin.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "6bc46efb34f689797b5302f54cbf439abb86acb6c47447df72ac894cb140e70f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-x86_64-apple-darwin.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-apple-darwin.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "712efe075399c6d837f4913f422cb3fc1a28bf59"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-apple-darwin.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "89296241b06c740a332130f3bd18b2f085cbd61aa8da13e737f7b5b7e2e07295"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-x86_64-apple-darwin.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-apple-darwin.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "f8d029758b9f574dd6f25c9c4946ba3e8b850d36"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-apple-darwin.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "ab228ba096b40c2b54a1f6817916888a1074fe3c0a7e2fa4523cd391fced3b8b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-x86_64-apple-darwin.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-apple-darwin.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "fe2c5743cb55ca6377be140260e7f983bca885c9"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-apple-darwin.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "96d4ed629b123d9fe677d25aaf2efdfe612e0dde53d5ef52b0e5fb9167fe0124"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-x86_64-apple-darwin.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-apple-darwin.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "7b1ba05990d4ee85dbdae526185de8cf902e65d3"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-apple-darwin.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "15b1417a2b8347489643d272ba811e81523a4b1ae832d81ce5515db5b54a4564"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-x86_64-apple-darwin.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-x86_64-linux-gnu.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "7c8a89e82ffdec87a9deb47375eea4b25953bc5b"
@@ -4111,6 +5255,94 @@ os = "linux"
     [["RustToolchain-x86_64-linux-gnu.v1.61.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "2993d0a4c0db63dd7a5128211db6303279044dc5825ac6a85c77b48ff32f703c"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-x86_64-linux-gnu.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-linux-gnu.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "97ff947b477bd498fe4768b6c28772024c3e4582"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-gnu.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "021fd4f26fe07fb21bb32b690a3b6282a239b7e2f5d8db4b9792390be21d9144"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-x86_64-linux-gnu.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-linux-gnu.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "35047a9798179a0d7bb40888c7e16485e8885316"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-gnu.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "4fb9eba30d2ff4b7e47e051733f22133d85e1acdd226e74fc1c8798848e0cbca"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-x86_64-linux-gnu.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-linux-gnu.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "20a60a08675e02377be53ea3001c377f14410686"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-gnu.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "4b51b40b211d8cb0ffec980684887574671711072ade5322c80d7b1d73988472"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-x86_64-linux-gnu.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-linux-gnu.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "ce33f129fd72d82738889b2ca032ee7ab107ec4d"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-gnu.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "2046c35740dfa183b6c1cd0c5a716cfae3c3f0cf45d74818319af4388d704a12"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-x86_64-linux-gnu.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-linux-gnu.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "8a87bde7bed8ee7d4fcad028e69ccca596e6c9d4"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-gnu.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "2b16c2b00536677f04df6303e4868334fb3224418c41a1d34df40c785c810d9e"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-x86_64-linux-gnu.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-linux-gnu.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "16e53f0090abe3b89aeb7be5a0a5b474cb470bad"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-gnu.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "fdc26c0f92502a427c1665a0c1efe541dba93c0a899f093a5f436aba521ff1d5"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-x86_64-linux-gnu.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-linux-gnu.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "3be8ef942111d55d60c8293d02d01c8ca49ee710"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-gnu.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "174cd377fe13f4d282bfdf1ccb7c625e973bbf211332d0ffc5a9804940c9d11d"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-x86_64-linux-gnu.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-linux-gnu.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "e841b28ff9fcdaa00cc209edaf9d29f0cd072f91"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-gnu.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "4149697ec9a3c4601e73b826214fee944148cb63f34ebf380cc5fae5d3a7b3d5"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-x86_64-linux-gnu.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustToolchain-x86_64-linux-musl.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -4178,6 +5410,94 @@ os = "linux"
     sha256 = "be07484c6467ffe1a26bc9013ce2bebb5e742944ce9c426b312b6afd749d2509"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-x86_64-linux-musl.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-x86_64-linux-musl.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "ea089be02643da6a607752b263790af4218d9329"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-musl.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "0ff6e2114140e2c66c1b634d0e31c3b8c908034a4d70bbf799508bb4033e605e"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-x86_64-linux-musl.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-linux-musl.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "79b53b21735835cbc696e30569a1be63b4c5506c"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-musl.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "2d3dd8ef0ee91da153713c1650fbd896df7a7781c2ebed9df71b7a543e575e80"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-x86_64-linux-musl.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-linux-musl.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "c738ff6615d34f91d73d2ec8789ed3cc1c2ea822"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-musl.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "36e87b014752ffa273ef44fa60901bfb9e893a63d90517d33535bd92bcec1cd1"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-x86_64-linux-musl.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-linux-musl.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "6a860d2dbe5f4a65f747973722ae9d949e8bb93d"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-musl.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "1b1055ec8d7feb6d4d49e093664e157718d1ae7488bdadb9fdd05b802741c72c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-x86_64-linux-musl.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-linux-musl.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "66e39322dc03eaf17286cec4448e890eb581b493"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-musl.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "b75fa36c1317fd45b42898540d1dc15eb14c5d295afc46b5c364f273ecf21ff2"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-x86_64-linux-musl.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-linux-musl.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "18125c1410145982774badbe8788b610d4b0e0ed"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-musl.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "c5cf75cf799a15eea15fb1d1953484518ed9030b5b1209b85f90eb7023559c40"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-x86_64-linux-musl.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-linux-musl.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "52ece84af28e4aa972a83017729c6e47e902090c"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-musl.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "9ef3264836493ae6f9221591b062d80033cefa049fca0e04558f288218c0e596"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-x86_64-linux-musl.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-linux-musl.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "6d3598db8cb4b36fc25b0554537bf1d59a09448e"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-linux-musl.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "53df62543c6d06e7d6f760f5d529c0b8afebdf1b82e8d4ac82df76f098b1371c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-x86_64-linux-musl.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-x86_64-unknown-freebsd.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "335de81ab0928b89bd4ef3d1db7a40925e5d9fe9"
@@ -4244,6 +5564,94 @@ os = "linux"
     sha256 = "a26d9d92755cabed6548703d2e5765975b94df1b8e705f2ae813bab3411ff20b"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-x86_64-unknown-freebsd.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
 
+[["RustToolchain-x86_64-unknown-freebsd.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "562b086a785477b93b0d3a7b39eb778408a3390a"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-unknown-freebsd.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "38efc2ba72ea4eec25a01690ea7debf698686b5670e67b1ebe217adfc83b5e10"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-x86_64-unknown-freebsd.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-unknown-freebsd.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "dc013913fa4939fb77d208eeb1908e945cc006e7"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-unknown-freebsd.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "bdea43332dce9bf63772f9928e668599fa7dfacfa81124d79ebd18e688111708"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-x86_64-unknown-freebsd.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-unknown-freebsd.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "08d611379cdfe5e127aa7b68869d7abaade43c9d"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-unknown-freebsd.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "99e923d72bda175156269b9ddfebdff476392a35641692198b2b3240ca9bb895"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-x86_64-unknown-freebsd.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-unknown-freebsd.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "4a446629916034cc462c3af4c162170e3451ac5f"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-unknown-freebsd.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "ebf54a106eaf1e189fefbae19b0d8151ecdb46ded07adfe81d96cf64cdd35d20"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-x86_64-unknown-freebsd.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-unknown-freebsd.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "51f807d86c170099851f5d3039297b72d6f11461"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-unknown-freebsd.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "5c29b6391136367cdd4eb907f45b9934335be284a360cf39e106ac03e71b214e"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-x86_64-unknown-freebsd.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-unknown-freebsd.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "b47c0a6a91f313e35ada5ad5d3ae082682247161"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-unknown-freebsd.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "534cd98ac5b387f1e1f5aa51e045e6ceb1eb69fbf242e6070489613410c3484f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-x86_64-unknown-freebsd.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-unknown-freebsd.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "9690242b2f30639c8e923dd7a65f599330afec6b"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-unknown-freebsd.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "76c2bdb289e0cd6565ffb1f0fa505919dd3d2189fd48e8731e178b015860b357"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-x86_64-unknown-freebsd.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-unknown-freebsd.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "c873ed68b4a6f30ad57c328c5a7459753c23d42a"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-unknown-freebsd.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "ee7dd34af7b25ebd5ec33a066969212837b077392e500534d7b5327a6ffb00d2"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-x86_64-unknown-freebsd.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"
+
 [["RustToolchain-x86_64-w64-mingw32.v1.57.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "2b17ca3fd848ee5460e5a18a589416edcf002cd2"
@@ -4309,3 +5717,91 @@ os = "linux"
     [["RustToolchain-x86_64-w64-mingw32.v1.61.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "aa811adc7537e426397d30945d2341c2b244c5975cdb844f98b2878aa41c5c09"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.61.0/RustToolchain-x86_64-w64-mingw32.v1.61.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-w64-mingw32.v1.62.1.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "b59a3cead1cbc3aec8c85dcf2194c6a8d8cab38d"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-w64-mingw32.v1.62.1.x86_64-linux-musl.squashfs".download]]
+    sha256 = "d457d39d238cf82c44d84993ba8ad9bf7a7a262e861928ad5678edb2d9038b3f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-x86_64-w64-mingw32.v1.62.1.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-w64-mingw32.v1.62.1.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "6d2af40e677e79ccb5b7222c211fbc78665a4bb2"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-w64-mingw32.v1.62.1.x86_64-linux-musl.unpacked".download]]
+    sha256 = "3c2c927be86bd5bfb6e9978f0c7c638898ad88b6ed3ff4622b3b791a5db38179"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.62.1/RustToolchain-x86_64-w64-mingw32.v1.62.1.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-w64-mingw32.v1.63.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "d8e4e6c089515c390578983aed792139faffcd9c"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-w64-mingw32.v1.63.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "1341ccfef7e3e0c3d341e359c2220083dadd9af5061ca9b0cac30b594eff5df4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-x86_64-w64-mingw32.v1.63.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-w64-mingw32.v1.63.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "47d1596dc45e020fb26d5e11e3616dccc463c812"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-w64-mingw32.v1.63.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "66968b1f0a8a7a89068daa030faab02816aa15bbd59ef36dd81018e8eea317dc"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.63.0/RustToolchain-x86_64-w64-mingw32.v1.63.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-w64-mingw32.v1.64.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "a548bd9a697e928af8adc380d5444dcc75a23a2a"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-w64-mingw32.v1.64.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "94d0d1f0cee38cc1ad724033c092ca45304d72b64ecd33c62c4a215a7570aa2d"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-x86_64-w64-mingw32.v1.64.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-w64-mingw32.v1.64.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "066bf02bb03b0d3e01e6184ffaf9411c254a120b"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-w64-mingw32.v1.64.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "3581b6d8151b6491b2d012d62f100c19ebcc69bcf3a882c5a087e2d84b0e0c4c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.64.0/RustToolchain-x86_64-w64-mingw32.v1.64.0.x86_64-linux-musl.unpacked.tar.gz"
+
+[["RustToolchain-x86_64-w64-mingw32.v1.65.0.x86_64-linux-musl.squashfs"]]
+arch = "x86_64"
+git-tree-sha1 = "6c3161623cfc3a5c8088fc7850f792e7514fa07a"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-w64-mingw32.v1.65.0.x86_64-linux-musl.squashfs".download]]
+    sha256 = "b19104f39f797ffbdc46364758db8963d65b05e183d98ff9fa2928dcf81f2266"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-x86_64-w64-mingw32.v1.65.0.x86_64-linux-musl.squashfs.tar.gz"
+
+[["RustToolchain-x86_64-w64-mingw32.v1.65.0.x86_64-linux-musl.unpacked"]]
+arch = "x86_64"
+git-tree-sha1 = "edc81189d2559f86a428747f5e1eba31755781e6"
+lazy = true
+libc = "musl"
+os = "linux"
+
+    [["RustToolchain-x86_64-w64-mingw32.v1.65.0.x86_64-linux-musl.unpacked".download]]
+    sha256 = "9283ef3441db6a89d9ca7131a062592da1e787cbb5b62cc2f6ae44d4f3dd2590"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/RustToolchain-v1.65.0/RustToolchain-x86_64-w64-mingw32.v1.65.0.x86_64-linux-musl.unpacked.tar.gz"

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -406,7 +406,10 @@ const available_llvm_builds = LLVMBuild.(get_available_builds("LLVMBootstrap."))
 
 const available_go_builds = GoBuild.(get_available_builds("Go."))
 
-const available_rust_builds = RustBuild.(get_available_builds("RustBase."))
+# We can't use newer versions of the Rust toolchain because it appears to be broken in our
+# environment.  More specifically, the wrong linker is picked up by cargo, despite the fact
+# we set the target platform with the environment variable `CARGO_BUILD_TARGET`.
+const available_rust_builds = RustBuild.(filter!(≤(v"1.61.0"), get_available_builds("RustBase.")))
 
 """
     gcc_version(p::AbstractPlatform, GCC_builds::Vector{GCCBuild},


### PR DESCRIPTION
Actually available builds are restricted to v1.61.0, the latest one we can use.