### PR TITLE
download all artifacts with concurrent tasks

### DIFF
--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -798,7 +798,7 @@ function expand_cxxstring_abis(platform::AbstractPlatform; skip=Sys.isbsd)
         p["cxxstring_abi"] = "cxx11" #Clang only seems to generate cxx11 abi
         return [p]
     end
-                                                                                                                                 
+
     # Otherwise, generate new versions!
     map(["cxx03", "cxx11"]) do abi
         p = deepcopy(platform)
@@ -1014,20 +1014,39 @@ function preferred_cxxstring_abi(platform::AbstractPlatform, shard::CompilerShar
 end
 
 """
-    download_all_artifacts(; verbose::Bool=false)
+    download_all_artifacts(; verbose::Bool=false, concurrency=1)
 
 Helper function to download all shards/helper binaries so that no matter what
 happens, you don't need an internet connection to build your precious, precious
 binaries.
 """
-function download_all_artifacts(; verbose::Bool = false)
+function download_all_artifacts(; verbose::Bool = false, concurrency=1)
     artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
-    ensure_all_artifacts_installed(
-        artifacts_toml;
-        include_lazy=true,
-        verbose=verbose,
-        platform=default_host_platform,
-    )
+    artifacts = select_downloadable_artifacts(artifacts_toml; platform=default_host_platform, include_lazy=true)
+    if concurrency == 1
+        for name in keys(artifacts)
+            ensure_artifact_installed(name, artifacts[name], artifacts_toml; verbose=verbose)
+        end
+        return nothing
+    end
+    taskpool = Channel{Task}(concurrency) do ch
+        for name in keys(artifacts)
+            t = @task ensure_artifact_installed(name, artifacts[name], artifacts_toml; verbose=false)
+            put!(ch, t)
+        end
+    end
+    verbose && @info "launch $concurrency concurrent downloading tasks"
+    wait(taskpool)
+    @sync for _ in 1:concurrency
+        @async begin
+            while !isempty(taskpool)
+                t = take!(taskpool)
+                schedule(t)
+                wait(t)
+            end
+        end
+    end
+    return nothing
 end
 
 const _sudo_cmd = Ref{Union{Cmd,Nothing}}(nothing)


### PR DESCRIPTION
It takes quite a long time to wait for each artifact to be downloaded if it's in a sequential manner, so I figure it might be worth adding concurrent support here.

But I'm not sure if this is implemented well. For instance, the downloading tasks can't be correctly killed if I hit Ctrl-C. Does Julia have a "standard" way of doing so? I found https://discourse.julialang.org/t/stop-terminate-a-sub-task-started-with-async/32193 but am not sure if that's okay to use.