### PR TITLE
[Dependency] Preserve `top_level` when converting `RuntimeDependency` -> `Dependency`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -47,8 +47,9 @@ Tar = "1.7"
 julia = "1.7"
 
 [extras]
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 ObjectFile = "d8793406-e978-5875-9003-1fc021f44a92"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ObjectFile", "Test"]
+test = ["ConstructionBase", "ObjectFile", "Test"]

--- a/src/Dependencies.jl
+++ b/src/Dependencies.jl
@@ -196,7 +196,7 @@ is_runtime_dependency(::RuntimeDependency) = true
 is_top_level_dependency(dep::RuntimeDependency) = dep.top_level
 # In some cases we may want to automatically convert a `RuntimeDependency` to a `Dependency`
 Base.convert(::Type{Dependency}, dep::RuntimeDependency) =
-    Dependency(dep.pkg; compat=dep.compat, platforms=dep.platforms)
+    Dependency(dep.pkg; compat=dep.compat, platforms=dep.platforms, top_level=dep.top_level)
 
 """
     BuildDependency(dep::Union{PackageSpec,String}; platforms)


### PR DESCRIPTION
First part of fixing https://github.com/JuliaPackaging/Yggdrasil/pull/6417#issuecomment-1476823499.

This was quite a yak-shaving, because while preparing the test I double checked that that new tests would fail without the change introduced here, which of course didn't happen, and realised that the current definition of `==` for `AbstractDependency` wasn't really sound.

Note: https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1273 reduces the need for such conversions, but doesn't entirely eliminate it.  I think it'd be better to try and avoid the conversion completely at a later point.