### PR TITLE
Update GCC 12.1 build for Windows to include libgomp fix

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1276,25 +1276,25 @@ os = "linux"
 
 [["GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "27f3b24d7d7a3db14854bd232058705a87bf0067"
+git-tree-sha1 = "3fb1988a200c37a80d249081ac99c2c667355453"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "7b79279adb8e376dd8c5e2696f3996ffbf3bce81ba002bc77be418a200a7135e"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+1/GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "b1c1bb7c794eb7c2f3602db4358eef947ea1d7680c8349bcdc509d96f336e5eb"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+2/GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "955429b1d52c55db14818621d35b3393250b7cc9"
+git-tree-sha1 = "698aa33b1a1a62c55bc1565d1082065f19c9c555"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "3e648d4cc705b0924651504a6105924c2c1e729a0792c3eb57eed87b51d3df4e"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+1/GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "6fb6df0f8de19f2b6573414e42057d2ac3d5167e4c3f11fa6dde3ad351c29aa3"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+2/GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v4.8.5.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -2464,25 +2464,25 @@ os = "linux"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "5814c3dd4045859df90b5962cc6ef174925cc3d9"
+git-tree-sha1 = "ebb8a0a2240c90037d4bb1e320d32b51ed6266a5"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "4f7ae9234290fd1e6763a73c1b1d605e91f26d1065ff2eda656a9af85f477a20"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+1/GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "2fe5bf73e185a840141f908a9bcab1f3fe2f0a0031aa9f5c88996c396aa84129"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+2/GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "b7a1b659c6537ce7947adac98ce047ce9f0aba2b"
+git-tree-sha1 = "6efaeff30ded95c8f8e7e79584544695346269b4"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "ea12bd8416d494b11c5e2b5e9d333d6568f96c81d8ee230a1469fd334f233636"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+1/GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "7f68ad106dafbd13502dac54ab2a737d483be4d4e97d4b24833560123ffd74d9"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+2/GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v4.8.5.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"


### PR DESCRIPTION
Ref: https://github.com/JuliaLang/julia/issues/48187.  @jd-foster found that this was due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105745, after applying the patch to our GCC 12.1 build @tylerjthomas9 reported that the new libgomp made tests of `XGBoost.jl` and `LIBSVM.jl` pass.

Other related issues:

* https://github.com/darktable-org/darktable/issues/11889
* https://github.com/msys2/MINGW-packages/issues/11729

Companion PR to https://github.com/JuliaPackaging/Yggdrasil/pull/6871.