### PR TITLE
[CI] Do not run full tests when using unpacked shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
   release:
 
 env:
-  BINARYBUILDER_FULL_SHARD_TEST: true
   BINARYBUILDER_AUTOMATIC_APPLE: true
 
 jobs:
@@ -19,6 +18,9 @@ jobs:
     env:
       BINARYBUILDER_RUNNER: ${{ matrix.runner }}
       BINARYBUILDER_USE_SQUASHFS: ${{ matrix.squashfs }}
+      # Run full tests only when we use the packed shards, because we constantly
+      # run out of disk on the free GitHub-hosted runners.
+      BINARYBUILDER_FULL_SHARD_TEST: ${{ matrix.squashfs }}
     strategy:
       fail-fast: false
       matrix:

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -443,7 +443,9 @@ end
             set -e
             make -j${nproc} -sC /usr/share/testsuite install
             """
-            @test run(ur, `/bin/bash -c "$(test_script)"`, iobuff; tee_stream=devnull)
+            # This test fails on GitHub Actions with non-squashfs:
+            # <https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/347>.
+            @test run(ur, `/bin/bash -c "$(test_script)"`, iobuff) broken=(get(ENV, "GITHUB_ACTIONS", "false")=="true" && !(BinaryBuilderBase.use_squashfs[]))
         end
     end
 end


### PR DESCRIPTION
Alternative to #321.  Not a great solution, but at least we can get _some_ tests to actually run.

Close #321.