### PR TITLE
Add new rebuilt mingw shards

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1342,223 +1342,223 @@ os = "linux"
 
 [["GCCBootstrap-i686-w64-mingw32.v10.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "f03a51f1f9f47e699a8b45b5f8f335026549f2bd"
+git-tree-sha1 = "88371ad9bc6992422fac48e924ba25534301a8e9"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v10.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "a3c34b54809be46b574d237a8d86b5fd891e21b44a511d15c29ee739752bc35b"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0/GCCBootstrap-i686-w64-mingw32.v10.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "14d28eb21d4e9456b4692c362d0d124d645ddd9b3f64b7c6b2ace8f8a82d7201"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+0/GCCBootstrap-i686-w64-mingw32.v10.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v10.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "ed70fda5a1a089b036f7f76bcf5759cb0d561691"
+git-tree-sha1 = "3a64a17e84519b58d8baeee211b4d96a457217b9"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v10.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "52c2a5c524a706a435fd955b7a65adef7e3ab27ecd1a5e1c829f2c1e2c98aeef"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0/GCCBootstrap-i686-w64-mingw32.v10.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "0e768889496ba3c07f8600a1f59727c67127cea8c4e7c2b27b8ea50794443fa9"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+0/GCCBootstrap-i686-w64-mingw32.v10.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v11.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "fd4411f1761515993df4a1966f7b5a287409d674"
+git-tree-sha1 = "a2ea94e7dd291435d31173af1b2040eba375fe52"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v11.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "0780d559a7c2815131fd6372a75806102f669cf63266ae6b28be567a8144c489"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v11.1.0/GCCBootstrap-i686-w64-mingw32.v11.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "026943295429abe059f3305bf23643e46e6fc8653e0f76f133a5815d8eaa3ad4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v11.1.0+0/GCCBootstrap-i686-w64-mingw32.v11.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v11.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "e1bc94f6f9eecddb9db7d43cba66e03f22a0d149"
+git-tree-sha1 = "107102b77e0a9335a89ac64e8b8c151c810f1f32"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v11.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "833934d865abf0090334d1e14006b36e8e3c67cac59ca89735e012f8224444a1"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v11.1.0/GCCBootstrap-i686-w64-mingw32.v11.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "a03648929d372dd29b5d1074e919744ad791958b292a6e10a69af62d802f7180"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v11.1.0+0/GCCBootstrap-i686-w64-mingw32.v11.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "3fb1988a200c37a80d249081ac99c2c667355453"
+git-tree-sha1 = "05c9696864f6440d3d0ad80e7a519f32837d7e97"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "b1c1bb7c794eb7c2f3602db4358eef947ea1d7680c8349bcdc509d96f336e5eb"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+2/GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "b63dc5663c5e051a447a3ea78505943ddd15aa078cf83afca8f4536b6b5ddd2d"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+3/GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "698aa33b1a1a62c55bc1565d1082065f19c9c555"
+git-tree-sha1 = "a4a08946545baded44147f49bb8d478e812fbbfa"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "6fb6df0f8de19f2b6573414e42057d2ac3d5167e4c3f11fa6dde3ad351c29aa3"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+2/GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "25aa53f87945a19a50395d1f6f104fbcefd53f771e5a3a6cbbde12a5bf7d524f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+3/GCCBootstrap-i686-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v13.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "305b28001d1e3d0076b374010588472279539263"
+git-tree-sha1 = "f4fca5794cf3bff2d6eb3cb2eaecabdbe8fe8996"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v13.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "762ae55c0123760c5b0a7d58ea4741191cbd36a2673d7030885c89faf0693a9c"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v13.2.0/GCCBootstrap-i686-w64-mingw32.v13.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "e683c06532a95426688bcd3ff510d4b723bbafcf4f3ef2cda347af7b54fa0d1d"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v13.2.0+0/GCCBootstrap-i686-w64-mingw32.v13.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v13.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "adecb9b9ca36ee763f16941fe9fd4cdc55aeaf42"
+git-tree-sha1 = "31e56c479b5688c7ba1a7d56ac06ef6a0865e91d"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v13.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "8a835047379f2ac76aa4f08e576f21cb6f174e4b8c6ec5d46594e5962f5341f4"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v13.2.0/GCCBootstrap-i686-w64-mingw32.v13.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "f46698e671283851ab5c4c35a748ccd5c4ee3727b5f92f26c981c1d84d8a0835"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v13.2.0+0/GCCBootstrap-i686-w64-mingw32.v13.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v4.8.5.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "495ab6de0e695d7f48bb8e87ececb6dc9e549d89"
+git-tree-sha1 = "f1a6253a6800a9df7b4ccfdc03df6962f05f2017"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v4.8.5.x86_64-linux-musl.squashfs".download]]
-    sha256 = "16f3e1cf8637ad5ff6d1c5f71b088e5e9b75cfb43faec8547460e6b87e9d04cf"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+2/GCCBootstrap-i686-w64-mingw32.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "0d6b07d4396d5dd4c5a00d7f519bb71d7802cb9c285d607a912e0530d10f99e1"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+3/GCCBootstrap-i686-w64-mingw32.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v4.8.5.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "2b334fd133e4e390da092b0d1d04b4a4b055c02d"
+git-tree-sha1 = "85974efbd51df7f813da43753b996a09aa57b0dd"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v4.8.5.x86_64-linux-musl.unpacked".download]]
-    sha256 = "4fbd1b321197b61adacc85dfae74852750b4a5e00db5dec19e53c5fdac411678"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+2/GCCBootstrap-i686-w64-mingw32.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "81b385905fda6d1cac1ff9594dbe48007e43a1b8dd4ad93ea62f1a87e90556e9"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+3/GCCBootstrap-i686-w64-mingw32.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v5.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "619811ead51371e21e2a64d19d964455b459f720"
+git-tree-sha1 = "4894197a492482817cd5076ab8b8ef4677e3f335"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v5.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "bbdd302842804bfc5e0bc287adb24d8f6267ebec09d7d7637f5e9ce314ba52ee"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+2/GCCBootstrap-i686-w64-mingw32.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "19cf5c4640cce37dd13f56701fa6895b46a2569a9a7a942f01a473ca12f71f2a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+3/GCCBootstrap-i686-w64-mingw32.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v5.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "03be69486aa04f2a9ab85146f52ebdbeff964cf9"
+git-tree-sha1 = "4f62d9f0d1e583272e54cb385fe733efd3c78078"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v5.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "422e275915e74c93a6226103f9672785521b403d2136de0321ea3cdcf8259cdc"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+2/GCCBootstrap-i686-w64-mingw32.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "3d8daf1c84a29c2715bbfb15c7f41f1ef825ec945accb59c6b970dbd38cc0fcb"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+3/GCCBootstrap-i686-w64-mingw32.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v6.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "212e7728ef5c8b2be5d455f55b169cf11e72d4b6"
+git-tree-sha1 = "13ae11f85ef86f40fefbe6ed8ca71ffe1ac58029"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v6.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "9e48a1561bfbad109b926633cb541e1f18c63e7b31810c346f391402580069b3"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+2/GCCBootstrap-i686-w64-mingw32.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "120a51cb841fa59d4052583c8b0a58a16cc0ad8442e51a4819ab4acd22dcd9ad"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+3/GCCBootstrap-i686-w64-mingw32.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v6.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "e5c88024594914a545181551299e27ce3d21a97b"
+git-tree-sha1 = "0018425392f50bb21f583f7c18f7e4211eac23b5"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v6.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "08e47a30b696e6abfa970c4784f767c7f8914376c22a1bad6b4aed5339df1744"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+2/GCCBootstrap-i686-w64-mingw32.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "613833ae7e721a817cae9243a5060cc9caff6badd5eb14cb6ef09012809bcb3e"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+3/GCCBootstrap-i686-w64-mingw32.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v7.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "81dee908d630c525b5d44b8192ad8e0db6d3d7ce"
+git-tree-sha1 = "5bd4d13590aed1549b79fe8d0b71f0a6396f0c1f"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v7.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "aac5c53397055a24a54a8632aeaf412306203ad157d14e64f3938871d23ffe4a"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+2/GCCBootstrap-i686-w64-mingw32.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "fb27204980cda2ef4bdf6382a9bbb99a0ac1ab374c5edeadb5acdf7e2c53b00a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+3/GCCBootstrap-i686-w64-mingw32.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v7.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "b198a2dc116bcdea960483448f9f2631308f3f0b"
+git-tree-sha1 = "af4b2dbb355cf83187f22daf664e21935e92e790"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v7.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "5586a005d770423ad734f3cccd0b983dadbca41d26fbf0433e442f1ed6f9a5ce"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+2/GCCBootstrap-i686-w64-mingw32.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "9ccd654910fd14a74d06502b6f59391711ba66e86a2c6178ba2fe0607ae606e2"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+3/GCCBootstrap-i686-w64-mingw32.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v8.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "30ad8acb5e6075e9c0568b900ade481f381fe75b"
+git-tree-sha1 = "ea5680b8c1015790fb22171cac83842598d61ac0"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v8.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "f8dba89df63a4871f9f391da6a8081ad2733962ec24dcc2eeb52aa0be97006b9"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+2/GCCBootstrap-i686-w64-mingw32.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "62ab993966d6795f5748b54893be2609774835112be05d918721a3e93f3ce175"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+3/GCCBootstrap-i686-w64-mingw32.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v8.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "91ab4b4b17e757f6823e6c2b8388c45e7895b8d6"
+git-tree-sha1 = "6e501c0e16b1905d2c0b83bf74732b237c1e16ef"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v8.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "dc709762291bbdb935fd0f3265fafd3c3f04ee02a595d335d0f0b1521dcfd0d6"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+2/GCCBootstrap-i686-w64-mingw32.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "f9eb60158090a5b6daecaedd623a78d7356e85036c29cce72bf5233f97fb66a4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+3/GCCBootstrap-i686-w64-mingw32.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v9.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "dda9f2c8d50be1d62673d7be500bc1ee34c1bce4"
+git-tree-sha1 = "808e059150d621aaff95cdaa72d5867fbdafd248"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v9.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "ad84a75eafe1906945d50cf2985f7f582fc0a1b148c8ac5cbeeabe30f70ad3af"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+2/GCCBootstrap-i686-w64-mingw32.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "f1db320d68516a4498cb3ad6718afaf3a554b3f698275f1f4ab6eb676002e115"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+3/GCCBootstrap-i686-w64-mingw32.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-i686-w64-mingw32.v9.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "bbd50eb1cc0779e20b2845a6adf87486995f1045"
+git-tree-sha1 = "efcbe1969713231b5ecccc8521f35af822dd4b72"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-i686-w64-mingw32.v9.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "2721699c9cf759ccec36fe2b0e636a6c2f725fab6c055ee44430536aa7f4583f"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+2/GCCBootstrap-i686-w64-mingw32.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "a5fa03de45d81c6a1ffb49220e0c179eae46ab9125d95da33bb1c8a94a4c5e6a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+3/GCCBootstrap-i686-w64-mingw32.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-powerpc64le-linux-gnu.v10.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
@@ -2662,223 +2662,223 @@ os = "linux"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v10.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "697f57b41fcfb94ba34c8e3d1c26a012dceaa5f9"
+git-tree-sha1 = "af973c5fc2bced0cbc90441273018bd3b059d732"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v10.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "f976ee57e32aebb09d2de04b49687deed9b40fbea0398aba763ca707a085b43d"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0/GCCBootstrap-x86_64-w64-mingw32.v10.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "26fab3d627405f0d083fb4b01cdb2f986f7d9d0c31cb2561c708bba40bf6ee71"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+0/GCCBootstrap-x86_64-w64-mingw32.v10.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v10.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "03a2b8e14e4abea9e138424dbbb3d968756d36de"
+git-tree-sha1 = "8752822091a8fd7b0ab863470dbf4aa76424176c"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v10.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "2c85bc7434a77f7f1b43c79cc3a0ed869cd0b312bb685ec55d03a5b88d39d57a"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0/GCCBootstrap-x86_64-w64-mingw32.v10.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "29bd912e8fc5ebe98d2f434750b89c5d0a482bcd43af03809bb6fb8cdd840235"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v10.2.0+0/GCCBootstrap-x86_64-w64-mingw32.v10.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v11.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "c3740f0f47090126f60428d907274eda8fba6969"
+git-tree-sha1 = "259770b45b7dbce295c1828052fda4fa0d31964e"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v11.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "edce55b5dc8807e03f6e7f15183fc236be4166c0ca9495375e9562827466f6bf"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v11.1.0/GCCBootstrap-x86_64-w64-mingw32.v11.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "3cec450edd11a62d82e6cd9a8b15755e6ff312e6d3245540b6806bd29d2c9bd0"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v11.1.0+0/GCCBootstrap-x86_64-w64-mingw32.v11.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v11.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "d370642542212c82cac52344712bc481a11c40f1"
+git-tree-sha1 = "0be19c0bf53b6b5374ac33407c799c934b7a13c1"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v11.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "b7840f7c752febfd73aa89315f4ff0f0a85a69f21b969a79662a3c93e03e51c5"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v11.1.0/GCCBootstrap-x86_64-w64-mingw32.v11.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "1f2cf768e2f1b9a6b27245717e275b51403b797856eb0d22ea7271878769dbb4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v11.1.0+0/GCCBootstrap-x86_64-w64-mingw32.v11.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "ebb8a0a2240c90037d4bb1e320d32b51ed6266a5"
+git-tree-sha1 = "0ff915ff78ff71d37bc595c59ad206453ea84faf"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "2fe5bf73e185a840141f908a9bcab1f3fe2f0a0031aa9f5c88996c396aa84129"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+2/GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "3813f40527048a177746f8e60c366ef265bbe7521028bdd4db21a80c1ada313a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+3/GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "6efaeff30ded95c8f8e7e79584544695346269b4"
+git-tree-sha1 = "ccb7e36888f1a663243204591629c9058460c8cf"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "7f68ad106dafbd13502dac54ab2a737d483be4d4e97d4b24833560123ffd74d9"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+2/GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "426b827e308b33509e88030f61d7e86efb885cc1b8da873c9cd0cadc0c2c6cab"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0+3/GCCBootstrap-x86_64-w64-mingw32.v12.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v13.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "30b398f5bca77af9cde8e833b11e176af03bac12"
+git-tree-sha1 = "45ead0c7885f714f7bce9a117a59c59dc651f97f"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v13.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "f04e251af56d70ab7d139b68eab1339e1b4f19efb5ec47de6285e5976ee76f3f"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v13.2.0/GCCBootstrap-x86_64-w64-mingw32.v13.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "a54a842bfb7557589ff8384f7bef70f114d33e63960eab7f82e8b4bd7bc7458f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v13.2.0+0/GCCBootstrap-x86_64-w64-mingw32.v13.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v13.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "637a8409f11f2c6200815f31a93b65437a477c36"
+git-tree-sha1 = "d1eeea5879d9f97429214f71fe6bffc71a925039"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v13.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "141e8788f424576aee095e744506f8e38efe0f366539a5cc9b03abd1b4d61e98"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v13.2.0/GCCBootstrap-x86_64-w64-mingw32.v13.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "f4264222001e84982291c12d8a1cb805bec17c0827e028f6ce1a35b666873211"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v13.2.0+0/GCCBootstrap-x86_64-w64-mingw32.v13.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v4.8.5.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "b56510a70da64a1e8f5206efa4100fd338074299"
+git-tree-sha1 = "012c231ccf9f5986d4d86d3775acafc1e8add725"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v4.8.5.x86_64-linux-musl.squashfs".download]]
-    sha256 = "987ddb0b073617ef418085aac1e36078694993e6d51abecdb9688bc8f88c615c"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+3/GCCBootstrap-x86_64-w64-mingw32.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "587b25cc7a26e50733bec8aee416bdc2bf1864009b84c5c2c24b9f2f932e4e8c"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+4/GCCBootstrap-x86_64-w64-mingw32.v4.8.5.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v4.8.5.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "217a1339fc81b7388fc8af3fc8a05bca7b7ced19"
+git-tree-sha1 = "8bf751a4dcefa5ad453409fad19cd15dddaeae3f"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v4.8.5.x86_64-linux-musl.unpacked".download]]
-    sha256 = "8f8084e8a8391b67d611f641e79ff72892fa84cf0e93702eaec133f01ccb61d1"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+3/GCCBootstrap-x86_64-w64-mingw32.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "9718e2c053d63a8570efbb0bb0351dc52db349a512d7e1f171010f36d941e77b"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v4.8.5+4/GCCBootstrap-x86_64-w64-mingw32.v4.8.5.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v5.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "daf4fe73a24fc28599072795093e51dbfa6397c1"
+git-tree-sha1 = "ed8ebf6f5bcbc8c0ececb99aaef0be1f65ed8c64"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v5.2.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "d17c4611cf8930a20fdcb83b3d305bdf523a07fae057de853e86877f253a1cdd"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+2/GCCBootstrap-x86_64-w64-mingw32.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "d76a474e999653bf2afe4b7ca607cdfdcdc9d25f7fe3d26780f202387cba4f56"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+3/GCCBootstrap-x86_64-w64-mingw32.v5.2.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v5.2.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "3568bec9bb84624f0c98cc4ab79c178ca7040eb5"
+git-tree-sha1 = "adfbf00a7e2bdf9463238a32355bc317608b1a88"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v5.2.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "e310c8d0faf30b00dbdba97776ab5cdd6fd4b28b2785555de2d9a02ca7b71be1"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+2/GCCBootstrap-x86_64-w64-mingw32.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "00766aaef9debb373c89338e66c50598ea5ae1b015a073720a71579149b391a4"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v5.2.0+3/GCCBootstrap-x86_64-w64-mingw32.v5.2.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v6.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "a24e2273a00a08cc2c6d852dcf0a9011c97136da"
+git-tree-sha1 = "9be316f454a4c177176f1a245dae4fb3a2e7c929"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v6.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "e01926f9ec5eab0f4e542f0bea9f5c6810aa1577c662b17489a806e67c88d68b"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+2/GCCBootstrap-x86_64-w64-mingw32.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "ff64689858275c820e77405c820244bb52c6af180ff73a579c047f8bb7d527ce"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+3/GCCBootstrap-x86_64-w64-mingw32.v6.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v6.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "238c8358640ad72c3ff888284e2adfd89402ada0"
+git-tree-sha1 = "3d1b280de66abf32b39b1fc945355a9e30316fd3"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v6.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "d5f3b04774be1e777da417587d512b5d9232840b435e8bc3c1a9a039203d4ff1"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+2/GCCBootstrap-x86_64-w64-mingw32.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "937e6ecf539cd1b4e3390171217d6ad2515c232a70da0999b5e9a2022b5df46a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v6.1.0+3/GCCBootstrap-x86_64-w64-mingw32.v6.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v7.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "b2b911c78b7835b8a69c81514cdb8af98a16f23f"
+git-tree-sha1 = "f6794666692c82aa6c72300f37002e121a09be33"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v7.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "841bbd16add56344dbef475ed83e4539b34a2cc492a43d9ce1b3c8e97be80be9"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+3/GCCBootstrap-x86_64-w64-mingw32.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "0772988b8c8f7ffb4364d8972ecf1c32ddb4dda4f025f65690f1ab8d0adc0cc7"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+4/GCCBootstrap-x86_64-w64-mingw32.v7.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v7.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "473a06c23aa7d96eb31580c4a8407826760c3943"
+git-tree-sha1 = "b375fd46aaee568f57552c093b9d661a009a08e8"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v7.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "59b335cb64a7564856876dd45e4dfc98771ed033850ba46fe3579c7ef00e6151"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+3/GCCBootstrap-x86_64-w64-mingw32.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "7e7a146842be74bc002f9c0e94be5409bb324227addbd6a729b8235f1b9c85ed"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+4/GCCBootstrap-x86_64-w64-mingw32.v7.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v8.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "ffac59d887a9494ec186f23f606042dcf84d63eb"
+git-tree-sha1 = "04fe6a96017366b13d09e67eedb8e7d7c3a888c3"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v8.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "8e6671bbe04930112418445f21dd0b47e6483b2ea4b0c388b72575d3ae790a35"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+3/GCCBootstrap-x86_64-w64-mingw32.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "9fc0a1c58b71d8fc2c356f55921e9d2cf404e075a8ba0fe6a359540990c8d0b0"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+4/GCCBootstrap-x86_64-w64-mingw32.v8.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v8.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "82dfc43ce7c5f20311e47b4f12d85461e72bdf0b"
+git-tree-sha1 = "8f690bb9cc953662a6e1a99936cad9a688688b13"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v8.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "e10880f988c83fc2ad993d1614d6bac5ef9a74296f164fa194d6c845e5412f40"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+3/GCCBootstrap-x86_64-w64-mingw32.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "fd092f807f75a316cfc579595bcdb303ff2562ae577f4c5e3202a7d2d7847804"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v8.1.0+4/GCCBootstrap-x86_64-w64-mingw32.v8.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v9.1.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "87e206d9748ebc285f22fd2651a7695d34bae1bd"
+git-tree-sha1 = "d876a9f5262faf4b870813a5c8497abd3f7218cb"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v9.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "6fdffcb0c29de1d3c61be74c3c0b76f3f110ff27896fd21abeb9997325ade857"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+3/GCCBootstrap-x86_64-w64-mingw32.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "056969b6f83545b0d501201b56c8425e0c8abdcd70c97b478a7b0d3d6ba4c04f"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+4/GCCBootstrap-x86_64-w64-mingw32.v9.1.0.x86_64-linux-musl.squashfs.tar.gz"
 
 [["GCCBootstrap-x86_64-w64-mingw32.v9.1.0.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "091b320afc91447b995ab1a44d38c1d7de429098"
+git-tree-sha1 = "1f6cc285a01659022d9169c3208e5cc58b6889d7"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["GCCBootstrap-x86_64-w64-mingw32.v9.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "a39d3f59dec5c0dbf7cfface166af35b322c90e25e52c1251f2f2476f1e20d38"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+3/GCCBootstrap-x86_64-w64-mingw32.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "cf5aa5c9d2388af7ad781e5b34ae1998a81a9221349d1f512b7ca86fda45004a"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+4/GCCBootstrap-x86_64-w64-mingw32.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["Go.v1.13.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -399,6 +399,7 @@ const available_gcc_builds = [
     GCCBuild(v"10.2.0", (libgfortran_version = v"5", libstdcxx_version = v"3.4.28", cxxstring_abi = "cxx11")),
     GCCBuild(v"11.1.0", (libgfortran_version = v"5", libstdcxx_version = v"3.4.29", cxxstring_abi = "cxx11")),
     GCCBuild(v"12.1.0", (libgfortran_version = v"5", libstdcxx_version = v"3.4.30", cxxstring_abi = "cxx11")),
+    GCCBuild(v"13.2.0", (libgfortran_version = v"5", libstdcxx_version = v"3.4.32", cxxstring_abi = "cxx11")),
     ## v"11.0.0-iains" is a very old build with some ABI incompatibilities with new versions (for example `libgcc_s`
     ## soversion, see https://github.com/JuliaLang/julia/issues/44435), let's pretend it never existed.
     # GCCBuild(v"11.0.0-iains", (libgfortran_version = v"5", libstdcxx_version = v"3.4.28", cxxstring_abi = "cxx11")),

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -177,7 +177,7 @@ end
         @test gcc_version(p, available_gcc_builds) == [v"7.1.0"]
 
         p = Platform("armv7l", "linux"; march="neonvfpv4")
-        @test gcc_version(p, available_gcc_builds) == [v"5.2.0", v"6.1.0", v"7.1.0", v"8.1.0", v"9.1.0", v"10.2.0", v"11.1.0", v"12.1.0", "v13.2.0", v"12.0.1-iains"]
+        @test gcc_version(p, available_gcc_builds) == [v"5.2.0", v"6.1.0", v"7.1.0", v"8.1.0", v"9.1.0", v"10.2.0", v"11.1.0", v"12.1.0", v"13.2.0", v"12.0.1-iains"]
 
         # When Rust is used on x86_64 Windows, we have to use at least binutils
         # 2.25, which we bundle with at least GCC 5.

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -177,7 +177,7 @@ end
         @test gcc_version(p, available_gcc_builds) == [v"7.1.0"]
 
         p = Platform("armv7l", "linux"; march="neonvfpv4")
-        @test gcc_version(p, available_gcc_builds) == [v"5.2.0", v"6.1.0", v"7.1.0", v"8.1.0", v"9.1.0", v"10.2.0", v"11.1.0", v"12.1.0", v"12.0.1-iains"]
+        @test gcc_version(p, available_gcc_builds) == [v"5.2.0", v"6.1.0", v"7.1.0", v"8.1.0", v"9.1.0", v"10.2.0", v"11.1.0", v"12.1.0", "v13.2.0", v"12.0.1-iains"]
 
         # When Rust is used on x86_64 Windows, we have to use at least binutils
         # 2.25, which we bundle with at least GCC 5.


### PR DESCRIPTION
This bumps the mingw runtime to the 11.0.1 version. mingw + mscvrt doesn't have version constraints because it's a statically linked runtime that links to  msvcrt.dll which is always there