### PR TITLE
Fix old clang/llvm version that broke after LLVM16

### DIFF
--- a/test/runners.jl
+++ b/test/runners.jl
@@ -124,13 +124,9 @@ end
     end
 
     # This tests only that compilers for all platforms can build and link simple C code
-    @testset "Compilation - $(platform) - $(compiler)" for platform in platforms, compiler in ("cc", "gcc", "clang"), version in (nothing, v"13")
+    @testset "Compilation - $(platform) - $(compiler)" for platform in platforms, compiler in ("cc", "gcc", "clang")
         mktempdir() do dir
-            if isnothing(version)
-                ur = preferred_runner()(dir; platform=platform)
-            else
-                ur = preferred_runner()(dir; platform=platform, preferred_gcc_version=version, preferred_llvm_version=version)
-            end
+            ur = preferred_runner()(dir; platform=platform)
             iobuff = IOBuffer()
             test_c = """
                 #include <stdlib.h>


### PR DESCRIPTION
While this doesn't fix the issues with LLVM16Bootstrap, this should restore the behaviour of the older versions. Also added a test on non default LLVM/GCC versions.