### PR TITLE
[Runner] Fix inclusion of `lib64` for PowerPC64 with GCC 6

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -542,9 +542,8 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     end
 
     function gcc_link_flags!(p::AbstractPlatform, flags::Vector{String} = String[])
-        # Yes, it does seem that the inclusion of `/lib64` on `powerpc64le` was fixed
-        # in GCC 6, broken again in GCC 7, and then fixed again for GCC 8 and 9
-        if arch(p) == "powerpc64le" && Sys.islinux(p) && gcc_version.major in (4, 5, 7)
+        # Inclusion of `/lib64` on `powerpc64le` was fixed in GCC 8+.
+        if arch(p) == "powerpc64le" && Sys.islinux(p) && 4 <= gcc_version.major <= 7
             append!(flags, String[
                 "-L/opt/$(aatriplet(p))/$(aatriplet(p))/sys-root/lib64",
                 "-Wl,-rpath-link,/opt/$(aatriplet(p))/$(aatriplet(p))/sys-root/lib64",


### PR DESCRIPTION
Tested with
`test.c`:
```c
#include <dlfcn.h>

void foo() {
    dlclose(dlopen("libc.so", RTLD_LOCAL | RTLD_LAZY));
}
```
`main.c`:
```c
void foo();

int main(void) {
    foo();
    return 0;
}
```
`Makefile`:
```make
main: main.c libtest.so
	SUPER_VERBOSE=1 cc -L. -o main main.c -ltest

libtest.so: test.c
	SUPER_VERBOSE=1 cc -shared -o libtest.so test.c -ldl
```

Before this PR:
```console
% julia --compile=min -e 'using BinaryBuilderBase; BinaryBuilderBase.runshell(Platform("powerpc64le", "linux"); preferred_gcc_version = v"6")'
sandbox:${WORKSPACE} # make -B
SUPER_VERBOSE=1 cc -shared -o libtest.so test.c -ldl
ccache /opt/powerpc64le-linux-gnu/bin/powerpc64le-linux-gnu-gcc -D_GLIBCXX_USE_CXX11_ABI=1 -frandom-seed=0x9847abb0 -L/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/lib64 -Wl,-rpath-link,/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/lib64 -mcpu=power8 -mtune=power8 -shared -o libtest.so test.c -ldl
SUPER_VERBOSE=1 cc -L. -o main main.c -ltest
ccache /opt/powerpc64le-linux-gnu/bin/powerpc64le-linux-gnu-gcc -D_GLIBCXX_USE_CXX11_ABI=1 -frandom-seed=0x0c79acbb -L/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/lib64 -Wl,-rpath-link,/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/lib64 -mcpu=power8 -mtune=power8 -L. -o main main.c -ltest
/opt/powerpc64le-linux-gnu/bin/../lib/gcc/powerpc64le-linux-gnu/6.1.0/../../../../powerpc64le-linux-gnu/bin/ld: warning: libdl.so.2, needed by ./libtest.so, not found (try using -rpath or -rpath-link)
./libtest.so: undefined reference to `dlopen@GLIBC_2.17'
./libtest.so: undefined reference to `dlclose@GLIBC_2.17'
collect2: error: ld returned 1 exit status
make: *** [Makefile:2: main] Error 1
```
with this PR:
```console
% julia --compile=min -e 'using BinaryBuilderBase; BinaryBuilderBase.runshell(Platform("powerpc64le", "linux"); preferred_gcc_version = v"6")'
sandbox:${WORKSPACE} # make -B
SUPER_VERBOSE=1 cc -shared -o libtest.so test.c -ldl
ccache /opt/powerpc64le-linux-gnu/bin/powerpc64le-linux-gnu-gcc -D_GLIBCXX_USE_CXX11_ABI=1 -frandom-seed=0x9847abb0 -L/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/lib64 -Wl,-rpath-link,/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/lib64 -mcpu=power8 -mtune=power8 -shared -o libtest.so test.c -ldl -L/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/lib64 -Wl,-rpath-link,/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/lib64
SUPER_VERBOSE=1 cc -L. -o main main.c -ltest
ccache /opt/powerpc64le-linux-gnu/bin/powerpc64le-linux-gnu-gcc -D_GLIBCXX_USE_CXX11_ABI=1 -frandom-seed=0x0c79acbb -L/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/lib64 -Wl,-rpath-link,/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/lib64 -mcpu=power8 -mtune=power8 -L. -o main main.c -ltest -L/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/lib64 -Wl,-rpath-link,/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/lib64
sandbox:${WORKSPACE} # 
```

Problem spotted at https://github.com/JuliaPackaging/Yggdrasil/pull/7501.