### PR TITLE
Default clang to use lld on specific conditions

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -187,6 +187,11 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
 
     target = aatriplet(platform)
     host_target = aatriplet(host_platform)
+    if (!isnothing(gcc_version) && !isnothing(clang_version) && clang_version >= v"16" && gcc_version >= v"5")
+        clang_use_lld = true
+    else
+        clang_use_lld = false
+    end
 
     function wrapper(io::IO,
                      prog::String;
@@ -409,6 +414,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             append!(flags, get_march_flags(arch(p), march(p), "clang"))
         end
         if Sys.isapple(p)
+            macos_version_flags = clang_use_lld ? (min_macos_version_flags()[1],) : min_macos_version_flags()
             append!(flags, String[
                 # On MacOS, we need to override the typical C++ include search paths, because it always includes
                 # the toolchain C++ headers first.  Valentin tracked this down to:
@@ -421,7 +427,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
                 # `clang` as a linker (and we have no real way to detect that in the wrapper), which will
                 # cause `clang` to complain about compiler flags being passed in.
                 "-Wno-unused-command-line-argument",
-                min_macos_version_flags()...,
+                macos_version_flags...,
             ])
         end
         sanitize_compile_flags!(p, flags)
@@ -467,7 +473,9 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         end
         # we want to use a particular linker with clang.  But we want to avoid warnings about unused
         # flags when just compiling, so we put it into "linker-only flags".
-        push!(flags, "-fuse-ld=$(aatriplet(p))")
+        if !clang_use_lld
+            push!(flags, "-fuse-ld=$(aatriplet(p))")
+        end
 
         sanitize_link_flags!(p, flags)
 

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -187,11 +187,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
 
     target = aatriplet(platform)
     host_target = aatriplet(host_platform)
-    if (!isnothing(gcc_version) && !isnothing(clang_version) && clang_version >= v"16" && gcc_version >= v"5")
-        clang_use_lld = true
-    else
-        clang_use_lld = false
-    end
+    clang_use_lld = (!isnothing(gcc_version) && !isnothing(clang_version) && clang_version >= v"16" && gcc_version >= v"5")
 
     function wrapper(io::IO,
                      prog::String;

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -348,7 +348,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             ])
             end
         end
-        if Sys.islinux(p) && !isnothing(gcc_version) && (clang_version >= v"16")
+        if Sys.islinux(p) && !isnothing(gcc_version) !isnothing(clang_version) && (clang_version >= v"16")
             append!(flags, ["--gcc-install-dir=/opt/$(aatriplet(p))/lib/gcc/$(aatriplet(p))/$(gcc_version)"])
         end
         if Sys.iswindows(p)

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -227,5 +227,13 @@ end
             @test occursin("GOOS=\"freebsd\"", read(joinpath(platform_bin_dir, "go"), String))
             @test occursin("--target=x86_64-unknown-freebsd", read(joinpath(platform_bin_dir, "rustc"), String))
         end
+        platform = Platform("x86_64", "linux"; libc="glibc", cxxstring_abi="cxx11")
+        mktempdir() do bin_path
+            platform_bin_dir = joinpath(bin_path, triplet(platform))
+            generate_compiler_wrappers!(platform; bin_path = bin_path, compilers = [:c], gcc_version=v"5")
+            clang = read(joinpath(platform_bin_dir, "clang"), String)
+            # Check link flags
+            @test occursin("-L/opt/$(aatriplet(platform))/lib/gcc/opt/$(aatriplet(platform))/lib/gcc", clang)
+        end
     end
 end

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -223,7 +223,6 @@ end
             clang = read(joinpath(platform_bin_dir, "clang"), String)
             # Check link flags
             @test occursin("-L/opt/$(triplet(platform))/$(triplet(platform))/lib", clang)
-            @test occursin("fuse-ld=$(triplet(platform))", clang)
             # Other compilers
             @test occursin("GOOS=\"freebsd\"", read(joinpath(platform_bin_dir, "go"), String))
             @test occursin("--target=x86_64-unknown-freebsd", read(joinpath(platform_bin_dir, "rustc"), String))

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -126,6 +126,11 @@ end
     # This tests only that compilers for all platforms can build and link simple C code
     @testset "Compilation - $(platform) - $(compiler)" for platform in platforms, compiler in ("cc", "gcc", "clang")
         mktempdir() do dir
+            # if compiler == "clang"
+            #     ur = preferred_runner()(dir; platform=platform, preferred_gcc_version=v"5") #TODO: Fix CI disk size issues to allow this
+            # else
+            #     ur = preferred_runner()(dir; platform=platform)
+            # end
             ur = preferred_runner()(dir; platform=platform)
             iobuff = IOBuffer()
             test_c = """


### PR DESCRIPTION
This switches clang to use lld when the clang version is 16 or above and the GCC version is 5 or above, It passes the commented out version of the test locally but given the issues we are seeing I'leaving it commented out for now.

The main goal of this is so that clang doesn't complain about very new linker features that the shipped binutils might not have.