### PR TITLE
Fixup lld code even more and make sure gcc can use it

### DIFF
--- a/src/BuildToolchains.jl
+++ b/src/BuildToolchains.jl
@@ -31,11 +31,11 @@ function cmake_os(p::AbstractPlatform)
     end
 end
 
+lld_str(p::AbstractPlatform) = Sys.isapple(p) ? "ld64.lld" : "ld.lld"
 function linker_string(p::AbstractPlatform, clang_use_lld)
     target = triplet(p)
     aatarget = aatriplet(p)
-    lld_str = Sys.isapple(p) ? "ld64.lld" : "ld.lld"
-    return clang_use_lld ? "/opt/bin/$(target)/$(lld_str)" : "/opt/bin/$(target)/$(aatarget)-ld"
+    return clang_use_lld ? "/opt/bin/$(target)/$(lld_str(p))" : "/opt/bin/$(target)/$(aatarget)-ld"
 end
 
 function toolchain_file(bt::CMake, p::AbstractPlatform, host_platform::AbstractPlatform; is_host::Bool=false, clang_use_lld::Bool=false)

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -471,7 +471,7 @@ end
             test_script = """
                 set -e
                 echo '$(test_c)' > test.c
-                cc -Werror -shared test.c -fuse-ld=lld -o libtest.\${dlext}
+                gcc -Werror -shared test.c -fuse-ld=lld -o libtest.\${dlext}
                 """
             cmd = `/bin/bash -c "$(test_script)"`
             @test run(ur, cmd, iobuff)
@@ -479,7 +479,7 @@ end
             test_script = """
             set -e
             echo '$(test_c)' > test.c
-            cc -Werror -v -shared test.c -fuse-ld=lld -o libtest.\${dlext}
+            gcc -Werror -v -shared test.c -fuse-ld=lld -o libtest.\${dlext}
             """
             iobuff = IOBuffer()
             cmd = `/bin/bash -c "$(test_script)"`


### PR DESCRIPTION
Fixes https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/349. Though -fuse-ld=lld is only available to GCC9 and up IIRC.
Also supercedes https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/342