### PR TITLE
Update README.md badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 ## BinaryBuilderBase.jl
 
-[![Build Status](https://travis-ci.com/JuliaPackaging/Binarybuilderbase.jl.svg?branch=master)](https://travis-ci.com/JuliaPackaging/Binarybuilderbase.jl)
+[![Build Status](https://github.com/JuliaPackaging/BinaryBuilderBase.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/JuliaPackaging/BinaryBuilderBase.jl/actions/workflows/ci.yml)
 
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliapackaging.github.io/BinaryBuilderBase.jl/stable)
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://juliapackaging.github.io/BinaryBuilderBase.jl/dev)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliapackaging.github.io/BinaryBuilderBase.jl/dev)
 
-[![Coverage Status](https://coveralls.io/repos/github/JuliaPackaging/BinaryBuilderBase.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaPackaging/BinaryBuilderBase.jl?branch=master)
 [![codecov](https://codecov.io/gh/JuliaPackaging/Binarybuilderbase.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaPackaging/Binarybuilderbase.jl)
 
 This package serves as foundation for


### PR DESCRIPTION
- CI is now on GitHub, not Travis
- coveralls status was last updated in 2020
- docs: latest is now called dev (and "latest" is confusing as one could think it refers to "latest release")