### PR TITLE
[Runner] Make `clang_use_lld` a keyword argument

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.28.0"
+version = "1.29.0"
 
 [deps]
 Bzip2_jll = "6e34b625-4abd-537c-b88f-471c36dfa7a0"

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -487,6 +487,20 @@ end
             seekstart(iobuff)
             @test occursin(r"lld", readchomp(iobuff))
         end
+
+        mktempdir() do dir
+            platform = Platform("x86_64", "linux", libc="musl")
+            ur = preferred_runner()(dir; platform, preferred_gcc_version=v"9", clang_use_lld=false)
+            iobuff = IOBuffer()
+            test_script = raw"""
+                cat $(which clang)
+                """
+            cmd = `/bin/bash -c "$(test_script)"`
+            @test run(ur, cmd, iobuff)
+            seekstart(iobuff)
+            @test occursin("-fuse-ld=$(aatriplet(platform))", readchomp(iobuff))
+        end
+
     end
 
 


### PR DESCRIPTION
I need to do more testing (hence opening as draft), but this might be sufficient to let users set `clang_use_lld` as keyword argument to `BinaryBuilder.build_tarballs`, so that they can easily opt-out of it.