### PR TITLE
improve error message for unsafe flags

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -308,7 +308,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         if length(unsafe_flags) >= 1
             write(io, """
             if [[ "\${ARGS[@]}" =~ \"$(join(unsafe_flags, "\"|\""))\" ]]; then
-                echo -e \"BinaryBuilder: You used one or more of the unsafe flags: $(join(unsafe_flags, ", "))\\nPlease repent.\" >&2
+                echo -e \"BinaryBuilder: You used one or more of the unsafe flags: $(join(unsafe_flags, ", "))\\nThis is not allowed, please remove all unsafe flags from your build script to continue.\" >&2
                 exit 1
             fi
             """)

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -308,7 +308,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         if length(unsafe_flags) >= 1
             write(io, """
             if [[ "\${ARGS[@]}" =~ \"$(join(unsafe_flags, "\"|\""))\" ]]; then
-                echo -e \"BinaryBuilder: You used one or more of the unsafe flags: $(join(unsafe_flags, ", "))\\nThis is not allowed, please remove all unsafe flags from your build script to continue.\" >&2
+                echo -e \"BinaryBuilder error: You used one or more of the unsafe flags: $(join(unsafe_flags, ", "))\\nThis is not allowed, please remove all unsafe flags from your build script to continue.\" >&2
                 exit 1
             fi
             """)

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -418,8 +418,8 @@ end
             @test !run(ur, cmd, iobuff; tee_stream=devnull)
             seekstart(iobuff)
             lines = readlines(iobuff)
-            @test lines[2] == "BinaryBuilder: You used one or more of the unsafe flags: -Ofast, -ffast-math, -funsafe-math-optimizations"
-            @test lines[3] == "Please repent."
+            @test lines[2] == "BinaryBuilder error: You used one or more of the unsafe flags: -Ofast, -ffast-math, -funsafe-math-optimizations"
+            @test lines[3] == "This is not allowed, please remove all unsafe flags from your build script to continue."
 
             ur = preferred_runner()(dir; platform=platform, allow_unsafe_flags=true)
             iobuff = IOBuffer()


### PR DESCRIPTION
This makes it clearer, that Binary builder actually doesn't allow unsafe flags and errors.