### PR TITLE
Mark broken test as passing

### DIFF
--- a/test/runners.jl
+++ b/test/runners.jl
@@ -545,10 +545,7 @@ end
             set -e
             make -j${nproc} -sC /usr/share/testsuite install
             """
-            # This test fails on GitHub Actions with non-squashfs on UserNS runners:
-            # <https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/347>.
-            is_broken = get(ENV, "GITHUB_ACTIONS", "false")=="true" && !(BinaryBuilderBase.use_squashfs[]) && BinaryBuilderBase.preferred_runner() == BinaryBuilderBase.UserNSRunner
-            @test run(ur, `/bin/bash -c "$(test_script)"`, iobuff) broken=is_broken
+            @test run(ur, `/bin/bash -c "$(test_script)"`, iobuff)
         end
     end
 end


### PR DESCRIPTION
The issue we were having before on GitHub-hosted Actions runners appears to have been fixed.

Close #347.