### PR TITLE
[Runner] Updated xcrun executable to handle a few arguments

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -1003,32 +1003,32 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         xcrun_path = joinpath(bin_path, triplet(platform), "xcrun")
         write(xcrun_path, """
               #!/bin/sh
-                          
-              sdk_path=\$SDKROOT
-                          
+
+              sdk_path="\$SDKROOT"
+
               show_sdk_path() {
                   echo "\$1"
               }
-                          
+
               show_sdk_version() {
-                  plistutil -f xml -i \$1/SDKSettings.plist
-                  | grep -A1 '<key>Version</key>' \
-                  | tail -n1 \
+                  plistutil -f xml -i "\$1"/SDKSettings.plist \\
+                  | grep -A1 '<key>Version</key>' \\
+                  | tail -n1 \\
                   | sed -E -e 's/\\s*<string>([^<]+)<\\/string>\\s*/\\1/'
               }
-                          
+
               while [ \$# -gt 0 ]; do
                   case "\$1" in
                       --sdk)
-                          sdk_path=\$2
+                          sdk_path="\$2"
                           shift 2
                           ;;
                       --show-sdk-path)
-                          show_sdk_path \$sdk_path
+                          show_sdk_path "\$sdk_path"
                           shift
                           ;;
                       --show-sdk-version)
-                          show_sdk_version \$sdk_path
+                          show_sdk_version "\$sdk_path"
                           shift
                           ;;
                       *)
@@ -1036,9 +1036,9 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
                           ;;
                   esac
               done
-              
+
               if [ \$# -gt 0 ]; then
-                "\$@"
+                  "\$@"
               fi
               """)
         chmod(xcrun_path, 0o775)

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -1037,7 +1037,7 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
                   esac
               done
 
-              if [[ "\${#}" -gt 0 ]]; then
+              if [ "\${#}" -gt 0 ]; then
                   exec "\${@}"
               fi
               """)

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -1004,31 +1004,31 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         write(xcrun_path, """
               #!/bin/sh
 
-              sdk_path="\$SDKROOT"
+              sdk_path="\${SDKROOT}"
 
               show_sdk_path() {
-                  echo "\$1"
+                  echo "\${1}"
               }
 
               show_sdk_version() {
-                  plistutil -f xml -i "\$1"/SDKSettings.plist \\
+                  plistutil -f xml -i "\${1}"/SDKSettings.plist \\
                   | grep -A1 '<key>Version</key>' \\
                   | tail -n1 \\
                   | sed -E -e 's/\\s*<string>([^<]+)<\\/string>\\s*/\\1/'
               }
 
-              while [ \$# -gt 0 ]; do
-                  case "\$1" in
+              while [ "\${#}" -gt 0 ]; do
+                  case "\${1}" in
                       --sdk)
-                          sdk_path="\$2"
+                          sdk_path="\${2}"
                           shift 2
                           ;;
                       --show-sdk-path)
-                          show_sdk_path "\$sdk_path"
+                          show_sdk_path "\${sdk_path}"
                           shift
                           ;;
                       --show-sdk-version)
-                          show_sdk_version "\$sdk_path"
+                          show_sdk_version "\${sdk_path}"
                           shift
                           ;;
                       *)
@@ -1037,8 +1037,8 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
                   esac
               done
 
-              if [ \$# -gt 0 ]; then
-                  "\$@"
+              if [[ "\${#}" -gt 0 ]]; then
+                  exec "\${@}"
               fi
               """)
         chmod(xcrun_path, 0o775)

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -1011,7 +1011,8 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
               }
                           
               show_sdk_version() {
-                  grep -A1 '<key>Version</key>' \$1/SDKSettings.plist \
+                  plistutil -f xml -i \$1/SDKSettings.plist
+                  | grep -A1 '<key>Version</key>' \
                   | tail -n1 \
                   | sed -E -e 's/\\s*<string>([^<]+)<\\/string>\\s*/\\1/'
               }

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -999,10 +999,46 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         # `xcrun` is another macOS-specific tool, which is occasionally needed to run some
         # commands, for example for the CGO linker.  Ref:
         # <https://github.com/JuliaPackaging/Yggdrasil/pull/2962>.
+        # Cf. <https://www.unix.com/man-page/osx/1/xcrun/>
         xcrun_path = joinpath(bin_path, triplet(platform), "xcrun")
         write(xcrun_path, """
               #!/bin/sh
-              exec "\${@}"
+                          
+              sdk_path=\$SDKROOT
+                          
+              show_sdk_path() {
+                  echo "\$1"
+              }
+                          
+              show_sdk_version() {
+                  grep -A1 '<key>Version</key>' \$1/SDKSettings.plist \
+                  | tail -n1 \
+                  | sed -E -e 's/\\s*<string>([^<]+)<\\/string>\\s*/\\1/'
+              }
+                          
+              while [ \$# -gt 0 ]; do
+                  case "\$1" in
+                      --sdk)
+                          sdk_path=\$2
+                          shift 2
+                          ;;
+                      --show-sdk-path)
+                          show_sdk_path \$sdk_path
+                          shift
+                          ;;
+                      --show-sdk-version)
+                          show_sdk_version \$sdk_path
+                          shift
+                          ;;
+                      *)
+                          break
+                          ;;
+                  esac
+              done
+              
+              if [ \$# -gt 0 ]; then
+                "\$@"
+              fi
               """)
         chmod(xcrun_path, 0o775)
     end
@@ -1255,6 +1291,7 @@ function platform_envs(platform::AbstractPlatform, src_name::AbstractString;
     if Sys.isapple(platform)
         mapping["LD"] = "/opt/bin/$(triplet(platform))/ld"
         mapping["MACOSX_DEPLOYMENT_TARGET"] = macos_version(platform)
+        mapping["SDKROOT"] = "/opt/$(aatriplet(platform))/$(aatriplet(platform))/sys-root"
     end
 
     # There is no broad agreement on what host compilers should be called,


### PR DESCRIPTION
Updated `xcrun` executable to handle `--sdk`, `--show-sdk-path` and `--show-sdk-version`.

Also, added `SDKROOT` env. var.

Usages of `xcrun --show-sdk-path` etc.:
* https://github.com/JuliaPackaging/Yggdrasil/pull/7507
* https://github.com/JuliaPackaging/Yggdrasil/pull/9785
* https://github.com/JuliaPackaging/Yggdrasil/pull/9797

## Expected behaviour

```sh
$ xcrun echo foo
foo

$ xcrun --show-sdk-path
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root

$ xcrun --show-sdk-version
10.12

$ xcrun --show-sdk-path --show-sdk-version
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root
10.12

$ xcrun --show-sdk-path --show-sdk-version echo foo
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root
10.12
foo

$ xcrun --sdk /opt/$target/$target/sys-root --show-sdk-path --show-sdk-version echo foo
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root
10.12
foo

$ xcrun --sdk $WORKSPACE/srcdir/MacOSX14.0.sdk --show-sdk-path --show-sdk-version echo foo
/workspace/srcdir/MacOSX14.0.sdk
14.0
foo
```