### PR TITLE
Allow specifying a Rust and Go toolchain version for the build

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.33.0"
+version = "1.34.0"
 
 [deps]
 Bzip2_jll = "6e34b625-4abd-537c-b88f-471c36dfa7a0"

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -666,9 +666,16 @@ function choose_shards(p::AbstractPlatform;
                 error("Requested Rust toolchain $(preferred_rust_version) not available in $(Rust_builds)")
             end
 
+            base_shard = find_shard("RustBase", Rust_build, archive_type)
+            toolchain_shard = find_shard("RustToolchain", Rust_build, archive_type; target=p)
+
+            if isnothing(toolchain_shard)
+                error("Requested Rust toolchain $(preferred_rust_version) not available on platform $(triplet(p))")
+            end
+
             append!(shards, [
-                find_shard("RustBase", Rust_build, archive_type),
-                find_shard("RustToolchain", Rust_build, archive_type; target=p),
+                base_shard,
+                toolchain_shard,
             ])
 
             if !platforms_match(p, default_host_platform)

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -1,6 +1,7 @@
 using Test
 using Base.BinaryPlatforms
 using BinaryBuilderBase
+using BinaryBuilderBase: RustBuild, CompilerShard
 
 @testset "Expand platforms" begin
     # expand_gfortran_versions
@@ -116,6 +117,17 @@ end
 
 @testset "Compiler Shards" begin
     @test_throws ErrorException CompilerShard("GCCBootstrap", v"4", Platform("x86_64", "linux"), :invalid_archive_type)
+
+    @testset "Rust toolchain selection" begin
+        platform = Platform("x86_64", "linux")
+        common_opts = (preferred_gcc_version=v"9", compilers=[:c, :rust])
+
+        shards = choose_shards(platform; preferred_rust_version = v"1.73", (common_opts)... )
+        @test filter(s-> s.name == "RustBase", shards)[end].version == v"1.73"
+        @test filter(s-> s.name == "RustToolchain", shards)[end].version == v"1.73"
+
+        @test_throws ErrorException choose_shards(platform; preferred_rust_version = v"1.78", (common_opts)...)
+    end
 
     @testset "GCC ABI matching" begin
         # Preferred libgfortran version and C++ string ABI

--- a/test/rootfs.jl
+++ b/test/rootfs.jl
@@ -129,6 +129,17 @@ end
         @test_throws ErrorException choose_shards(platform; preferred_rust_version = v"1.78", (common_opts)...)
     end
 
+    @testset "Go toolchain selection" begin
+        platform = Platform("x86_64", "linux")
+        common_opts = (preferred_gcc_version=v"9", compilers=[:c, :go])
+
+        shards = choose_shards(platform; preferred_go_version = v"1.13", (common_opts)... )
+        @test filter(s-> s.name == "Go", shards)[end].version == v"1.13"
+
+        # 1.14 was never added, so use that as the testcase here
+        @test_throws ErrorException choose_shards(platform; preferred_go_version = v"1.14", (common_opts)...)
+    end
+
     @testset "GCC ABI matching" begin
         # Preferred libgfortran version and C++ string ABI
         platform = Platform("x86_64", "freebsd")


### PR DESCRIPTION
This exposes two new keyword arguments for finding the shards: `preferred_rust_version` and `preferred_go_version`, which will specify the version of the toolchain to use. Note these are implemented as strict requests for now, but I kept the "preferred" name to match the gcc and llvm arguments.

I know the Rust toolchain is probably fine as a strict request, but I don't know about Go's commitment to compatibility across compiler versions.