### PR TITLE
Always use GCC >5 when building Rust

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.34.0"
+version = "1.34.1"
 
 [deps]
 Bzip2_jll = "6e34b625-4abd-537c-b88f-471c36dfa7a0"

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -480,7 +480,9 @@ function gcc_version(p::AbstractPlatform,
 
     # Rust on Windows requires binutils 2.25 (it invokes `ld` with `--high-entropy-va`),
     # which we bundle with GCC 5.
-    if :rust in compilers && Sys.iswindows(p)
+    # Rust requires glibc 2.17 (https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html),
+    # which we only use for GCC >5
+    if :rust in compilers
         GCC_builds = filter(b -> getversion(b) ≥ v"5", GCC_builds)
     end
 


### PR DESCRIPTION
Rust requires glibc 2.17, which we only have with GCC >5. This at least fixes the x86_64 failure seen in the BinaryBuilder CI https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1358, which is giving the error:

```
          /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/sys/pal/unix/stack_overflow.rs:270: undefined reference to `getauxval'
          /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/sys/pal/unix/stack_overflow.rs:270: undefined reference to `getauxval'
          collect2: error: ld returned 1 exit status
```