### PR TITLE
[RootFS] Use GCC 13+ for riscv64

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1956,28 +1956,6 @@ os = "linux"
     sha256 = "d49106316ef5a4dc8cbce8665e720526a921cbba89dc38be41d53fc65c18007f"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v9.1.0+2/GCCBootstrap-powerpc64le-linux-gnu.v9.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
-[["GCCBootstrap-riscv64-linux-gnu.v12.1.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "0e0e172850698ee5784355eebeaf661278cfc489"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["GCCBootstrap-riscv64-linux-gnu.v12.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "a51037a3b4eff64d08f63c48d16a5b873833d83a2085ac365cf11b0918c503cf"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0/GCCBootstrap-riscv64-linux-gnu.v12.1.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["GCCBootstrap-riscv64-linux-gnu.v12.1.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "55460cf13be2ec9fe829768b49ea5b2ba49954ef"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["GCCBootstrap-riscv64-linux-gnu.v12.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "671879f013264f1627b5bff6ec246fd2806b4bc1ae9db74390df7004e00891d5"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0/GCCBootstrap-riscv64-linux-gnu.v12.1.0.x86_64-linux-musl.unpacked.tar.gz"
-
 [["GCCBootstrap-riscv64-linux-gnu.v13.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
 git-tree-sha1 = "83e2aeef1b7ff0abe246d83065877e36f270bb32"
@@ -1999,28 +1977,6 @@ os = "linux"
     [["GCCBootstrap-riscv64-linux-gnu.v13.2.0.x86_64-linux-musl.unpacked".download]]
     sha256 = "fc2b0c57b83c22416cdab285b8e3efaa3c55988d1a771e2ade6308d6b24674f5"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v13.2.0/GCCBootstrap-riscv64-linux-gnu.v13.2.0.x86_64-linux-musl.unpacked.tar.gz"
-
-[["GCCBootstrap-riscv64-linux-musl.v12.1.0.x86_64-linux-musl.squashfs"]]
-arch = "x86_64"
-git-tree-sha1 = "0a988108fd945733a2b493ae398b67588abc0e32"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["GCCBootstrap-riscv64-linux-musl.v12.1.0.x86_64-linux-musl.squashfs".download]]
-    sha256 = "2fe11e0f794df6af2ab39b8e6d1c4efc32cdb792fd045409cdcedd96d643a1c5"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0/GCCBootstrap-riscv64-linux-musl.v12.1.0.x86_64-linux-musl.squashfs.tar.gz"
-
-[["GCCBootstrap-riscv64-linux-musl.v12.1.0.x86_64-linux-musl.unpacked"]]
-arch = "x86_64"
-git-tree-sha1 = "a10265906d9a12bbc7a2a9a6ed0a4d67cb6a3ad0"
-lazy = true
-libc = "musl"
-os = "linux"
-
-    [["GCCBootstrap-riscv64-linux-musl.v12.1.0.x86_64-linux-musl.unpacked".download]]
-    sha256 = "d958a67682d30ea9e04116db4f463c17f0bf63823e352692d5fe7982da86e220"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v12.1.0/GCCBootstrap-riscv64-linux-musl.v12.1.0.x86_64-linux-musl.unpacked.tar.gz"
 
 [["GCCBootstrap-riscv64-linux-musl.v13.2.0.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.34.1"
+version = "1.34.2"
 
 [deps]
 Bzip2_jll = "6e34b625-4abd-537c-b88f-471c36dfa7a0"

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -472,10 +472,9 @@ function gcc_version(p::AbstractPlatform,
         GCC_builds = filter(b -> getversion(b) ≥ v"7", GCC_builds)
     end
 
-    # We only have GCC 12 or newer for RISC-V.
-    # (This could be changed down to GCC 7.1.)
+    # We only have GCC 13 or newer for RISC-V.
     if arch(p) == "riscv64"
-        GCC_builds = filter(b -> getversion(b) ≥ v"12", GCC_builds)
+        GCC_builds = filter(b -> getversion(b) ≥ v"13", GCC_builds)
     end
 
     # Rust on Windows requires binutils 2.25 (it invokes `ld` with `--high-entropy-va`),


### PR DESCRIPTION
We've had a few problems with GCC 12 on riscv64 (missing `riscv_vector.h` header file, broken support for atomics) that we're often forced to use GCC 13.  Let's always use GCC 13 at minimum and live happier.

Once we get GCC 14 in we may bump the minimum riscv64 GCC toolchain to that version, because it introduces better support for the version 1.0 of the vector extension, important for OpenBLAS and other software.