### PR TITLE
[Runner] Work around wrong path of compiler libraries for riscv64

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -555,7 +555,8 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
             # the wrappers before any additional arguments because we want this path to have
             # precedence over anything else.  In this way for example we avoid libraries
             # from `CompilerSupportLibraries_jll` in `${libdir}` are picked up by mistake.
-            dir = "/opt/$(aatriplet(p))/$(aatriplet(p))/lib" * (nbits(p) == 32 ? "" : "64")
+            # Note 2: Compiler libraries for riscv64 ended up in `lib/` by mistake.
+            dir = "/opt/$(aatriplet(p))/$(aatriplet(p))/lib" * (nbits(p) == 32 || arch(p) == "riscv64" ? "" : "64")
             append!(flags, ("-L$(dir)", "-Wl,-rpath-link,$(dir)"))
         end
         if lock_microarchitecture


### PR DESCRIPTION
Ref https://github.com/JuliaPackaging/Yggdrasil/pull/10204#issuecomment-2573845355.