### PR TITLE
[Runner] Adjust clang flags to make it work slightly better on Linux

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.35.0"
+version = "1.35.1"
 
 [deps]
 Bzip2_jll = "6e34b625-4abd-537c-b88f-471c36dfa7a0"

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -476,10 +476,6 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
                     "-isystem /opt/$(aatriplet(p))/$(aatriplet(p))/include",
                 ])
             end
-            # Extra stuff
-            append!(flags, [
-                # "-isystem /opt/$(aatriplet(p))/$(aatriplet(p))/sys-root/include", # <-- this directory doesn't exist out-of-the box (unless manually created to put libc++ in its subdirs, but this would remain without header files anyway), commenting out for the time being
-            ])
         end
 
         if Sys.iswindows(p) && nbits(p) == 32

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -394,7 +394,6 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
     end
 
     function sanitize_compile_flags!(p::AbstractPlatform, flags::Vector{String})
-        san = sanitize(p)
         if sanitize(p) !== nothing
             if sanitize(p) == "memory"
                 append!(flags, ["-fsanitize=memory"])
@@ -427,41 +426,36 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         if lock_microarchitecture
             append!(flags, get_march_flags(arch(p), march(p), "clang"))
         end
+
+        append!(flags, [
+            # We add `-Wno-unused-command-line-argument` so that if someone does something like
+            # `clang -Werror -o foo a.o b.o`, it doesn't complain due to the fact that that is using
+            # `clang` as a linker (and we have no real way to detect that in the wrapper), which
+            # will cause `clang` to complain about compiler flags being passed in.
+            "-Wno-unused-command-line-argument",
+            # We need to override the typical C++ include search paths, because it always includes
+            # the toolchain C++ headers first.  Valentin tracked this down to:
+            # https://github.com/llvm/llvm-project/blob/0378f3a90341d990236c44f297b923a32b35fab1/clang/lib/Driver/ToolChains/Darwin.cpp#L1944-L1978
+            "-nostdinc++",
+            # For systems other than macOS this directory doesn't exist out-of-the-box in our
+            # toolchain, but you can put in there the headers of the C++ standard library for libc++
+            # from LLLVMLibcxx_jll.  This must come before GCC header files (added below).
+            "-isystem /opt/$(aatriplet(p))/$(aatriplet(p))/sys-root/usr/include/c++/v1",
+        ])
+
         if Sys.isapple(p)
             macos_version_flags = clang_use_lld ? (min_macos_version_flags()[1],) : min_macos_version_flags()
             append!(flags, String[
-                # On MacOS, we need to override the typical C++ include search paths, because it always includes
-                # the toolchain C++ headers first.  Valentin tracked this down to:
-                # https://github.com/llvm/llvm-project/blob/0378f3a90341d990236c44f297b923a32b35fab1/clang/lib/Driver/ToolChains/Darwin.cpp#L1944-L1978
-                "-nostdinc++",
-                "-isystem",
-                "/opt/$(aatriplet(p))/$(aatriplet(p))/sys-root/usr/include/c++/v1",
-                # We also add `-Wno-unused-command-line-argument` so that if someone does something like
-                # `clang -Werror -o foo a.o b.o`, it doesn't complain due to the fact that that is using
-                # `clang` as a linker (and we have no real way to detect that in the wrapper), which will
-                # cause `clang` to complain about compiler flags being passed in.
-                "-Wno-unused-command-line-argument",
                 macos_version_flags...,
             ])
         end
+
         sanitize_compile_flags!(p, flags)
         if Sys.isfreebsd(p)
             add_system_includedir(flags)
         end
 
         if !Sys.isbsd(p)
-            # libc++ header files
-            append!(flags, [
-                # NOTE: this first directory doesn't exist out-of-the-box in our toolchain,
-                # but you should put in there the C++ standard libraries for libc++ from
-                # LLLVMLibcxx_jll.  This must come before GCC header files (added below).
-                "-isystem /opt/$(aatriplet(p))/$(aatriplet(p))/sys-root/include/c++/v1",
-                # This directory contains C header files.  Must come after the C++ ones, see
-                # for example <https://github.com/llvm/llvm-project/blob/4bcdb26dac4cdadd7f8850a5f9b2e775b73aaf7f/libcxx/include/cmath#L336-L338>.
-                # This directory is in default search paths, but we have to explicitly put
-                # it here to give it higher precedence than the following directories.
-                "-isystem /opt/$(aatriplet(p))/$(aatriplet(p))/sys-root/usr/include",
-            ])
             # GCC header files
             if !isnothing(gcc_version)
                 append!(flags, [


### PR DESCRIPTION
The current order of header search paths of clang targeting platforms different than macOS and FreeBSD makes it somewhat broken:
```console
% julia -e 'using BinaryBuilderBase; BinaryBuilderBase.runshell(Platform("aarch64", "linux"))'
sandbox:${WORKSPACE} # echo -e '#include <cstdint>\nint main(){return 0;}'|clang -x c++ - -H -o /dev/null
. /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/cstdint
.. /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/aarch64-linux-gnu/bits/c++config.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/aarch64-linux-gnu/bits/os_defines.h
.... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/features.h
..... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/stdc-predef.h
..... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/sys/cdefs.h
...... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/wordsize.h
..... /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/gnu/stubs.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/aarch64-linux-gnu/bits/cpu_defines.h
.. /opt/x86_64-linux-musl/bin/../include/c++/v1/stdint.h
... /opt/x86_64-linux-musl/bin/../include/c++/v1/__config
In file included from <stdin>:1:
In file included from /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/cstdint:41:
In file included from /opt/x86_64-linux-musl/bin/../include/c++/v1/stdint.h:106:
/opt/x86_64-linux-musl/bin/../include/c++/v1/__config:13:10: fatal error: '__config_site' file not found
   13 | #include <__config_site>
      |          ^~~~~~~~~~~~~~~
... /opt/x86_64-linux-musl/lib/clang/18/include/stdint.h
.... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/stdint.h
..... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/wchar.h
..... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/wordsize.h
1 error generated.
```
By moving `/opt/${target}/${target}/sys-root/usr/include` further up we get a more functional C++ compiler:
```console
% julia -e 'using BinaryBuilderBase; BinaryBuilderBase.runshell(Platform("aarch64", "linux"))'
sandbox:${WORKSPACE} # echo -e '#include <cstdint>\nint main(){return 0;}'|clang -x c++ - -H -o /dev/null
. /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/cstdint
.. /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/aarch64-linux-gnu/bits/c++config.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/aarch64-linux-gnu/bits/os_defines.h
.... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/features.h
..... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/stdc-predef.h
..... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/sys/cdefs.h
...... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/wordsize.h
..... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/gnu/stubs.h
...... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/wordsize.h
...... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/gnu/stubs-lp64.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/aarch64-linux-gnu/bits/cpu_defines.h
.. /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/stdint.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/wchar.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/wordsize.h
sandbox:${WORKSPACE} # echo -e '#include <cmath>\nint main(){return 0;}'|clang -x c++ - -H -o /dev/null
. /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/cmath
.. /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/aarch64-linux-gnu/bits/c++config.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/aarch64-linux-gnu/bits/os_defines.h
.... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/features.h
..... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/stdc-predef.h
..... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/sys/cdefs.h
...... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/wordsize.h
..... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/gnu/stubs.h
...... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/wordsize.h
...... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/gnu/stubs-lp64.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/aarch64-linux-gnu/bits/cpu_defines.h
.. /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/bits/cpp_type_traits.h
.. /opt/aarch64-linux-gnu/aarch64-linux-gnu/include/c++/4.8.5/ext/type_traits.h
.. /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/math.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/huge_val.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/huge_valf.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/huge_vall.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/inf.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/nan.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/mathdef.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/mathcalls.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/mathcalls.h
... /opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/include/bits/mathcalls.h
```

Also, do some general cleanup.