### PR TITLE
Add a test for installing a dependency with a specific version number

### DIFF
--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -367,6 +367,33 @@ end
                 end
             end
         end
+
+        @testset "PackageSpec with version" begin
+            # Install a dependency with a specific version number.
+            with_temp_project() do dir
+                prefix = Prefix(dir)
+                dependencies = [
+                    PackageSpec(; name="CMake_jll", version = v"3.24.3")
+                ]
+                platform = Platform("x86_64", "linux"; libc="musl", cxxstring_abi="cxx11")
+                try
+                    test_setup_dependencies(prefix, dependencies, platform)
+                catch
+                    if VERSION>=v"1.9"
+                        # This test is expected to be broken on Julia v1.9+
+                        @test false broken=true
+                    else
+                        # For previous versions we don't expect errors and we
+                        # want to see them.
+                        rethrow()
+                    end
+                end
+                # The directory contains also executables from CMake dependencies.
+                # Test will fail if `setup_dependencies` above failed.
+                @test readdir(joinpath(destdir(dir, platform), "bin")) == ["c_rehash", "cmake", "cpack", "ctest", "openssl"] broken=VERSION>=v"1.9"
+            end
+        end
+
     end
 end
 

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -376,32 +376,21 @@ end
                     PackageSpec(; name="CMake_jll", version = v"3.24.3")
                 ]
                 platform = Platform("x86_64", "linux"; libc="musl", cxxstring_abi="cxx11")
-                @show VERSION
-                @show VERSION>=v"1.9"
                 try
-                    @info "" @__LINE__
                     test_setup_dependencies(prefix, dependencies, platform)
-                    @info "" @__LINE__
                 catch
-                    @info "" @__LINE__
                     if VERSION>=v"1.9"
-                        @info "" @__LINE__
                         # This test is expected to be broken on Julia v1.9+
                         @test false broken=true
-                        @info "" @__LINE__
                     else
-                        @info "" @__LINE__
                         # For previous versions we don't expect errors and we
                         # want to see them.
                         rethrow()
-                        @info "" @__LINE__
                     end
                 end
-                @info "" @__LINE__
                 # The directory contains also executables from CMake dependencies.
                 # Test will fail if `setup_dependencies` above failed.
                 @test readdir(joinpath(destdir(dir, platform), "bin")) == ["c_rehash", "cmake", "cpack", "ctest", "openssl"] broken=VERSION>=v"1.9"
-                @info "" @__LINE__
             end
         end
 

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -376,21 +376,32 @@ end
                     PackageSpec(; name="CMake_jll", version = v"3.24.3")
                 ]
                 platform = Platform("x86_64", "linux"; libc="musl", cxxstring_abi="cxx11")
+                @show VERSION
+                @show VERSION>=v"1.9"
                 try
+                    @info "" @__LINE__
                     test_setup_dependencies(prefix, dependencies, platform)
+                    @info "" @__LINE__
                 catch
+                    @info "" @__LINE__
                     if VERSION>=v"1.9"
+                        @info "" @__LINE__
                         # This test is expected to be broken on Julia v1.9+
                         @test false broken=true
+                        @info "" @__LINE__
                     else
+                        @info "" @__LINE__
                         # For previous versions we don't expect errors and we
                         # want to see them.
                         rethrow()
+                        @info "" @__LINE__
                     end
                 end
+                @info "" @__LINE__
                 # The directory contains also executables from CMake dependencies.
                 # Test will fail if `setup_dependencies` above failed.
                 @test readdir(joinpath(destdir(dir, platform), "bin")) == ["c_rehash", "cmake", "cpack", "ctest", "openssl"] broken=VERSION>=v"1.9"
+                @info "" @__LINE__
             end
         end
 

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -376,16 +376,25 @@ end
                     PackageSpec(; name="CMake_jll", version = v"3.24.3")
                 ]
                 platform = Platform("x86_64", "linux"; libc="musl", cxxstring_abi="cxx11")
-                try
-                    test_setup_dependencies(prefix, dependencies, platform)
-                catch
-                    if VERSION>=v"1.9"
-                        # This test is expected to be broken on Julia v1.9+
-                        @test false broken=true
-                    else
-                        # For previous versions we don't expect errors and we
-                        # want to see them.
-                        rethrow()
+                if v"1.9" <= VERSION < v"1.11"
+                    # For reasons I can't understand, in CI on GitHub Actions (and only
+                    # there, can't reproduce the same behaviour locally) the error thrown
+                    # inside the `setup_dependencies` "escapes" the `try` block. For lack of
+                    # time to debug this stupid thing we just mark this step as broken and
+                    # move on, it's really broken anyway.
+                    @test false broken=true
+                else
+                    try
+                        test_setup_dependencies(prefix, dependencies, platform)
+                    catch
+                        if VERSION>=v"1.9"
+                            # This test is expected to be broken on Julia v1.9+
+                            @test false broken=true
+                        else
+                            # For previous versions we don't expect errors and we
+                            # want to see them.
+                            rethrow()
+                        end
                     end
                 end
                 # The directory contains also executables from CMake dependencies.


### PR DESCRIPTION
The test being added here triggers https://github.com/JuliaPackaging/Yggdrasil/pull/10524#issuecomment-2657162519 in Julia v1.9-11 and https://github.com/JuliaPackaging/Yggdrasil/pull/10524#issuecomment-2660939179 on current `master` (https://github.com/JuliaLang/julia/commit/c93e28e8a2437c906f2c0dd21c200dde690a0fb2).  Adding the test here as a reference of an operation we want to make sure works correctly.