### PR TITLE
RISCV: Add CMake variable to set the system library directory

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.36.0"
+version = "1.37.0"
 
 [deps]
 Bzip2_jll = "6e34b625-4abd-537c-b88f-471c36dfa7a0"

--- a/src/BuildToolchains.jl
+++ b/src/BuildToolchains.jl
@@ -94,6 +94,14 @@ function toolchain_file(bt::CMake, p::AbstractPlatform, host_platform::AbstractP
         set(CMAKE_SYSROOT /opt/$(aatarget)/$(aatarget)/sys-root/)
         """
     end
+
+    if arch(p) == "riscv64"
+        # RISCV libraries are in a subdirectory corresponding to the ABI of the processor
+        file *= """
+        set(CMAKE_SYSTEM_LIBRARY_PATH \${CMAKE_SYSROOT}/usr/lib64/lp64d)
+        """
+    end
+
     file *= """
         set(CMAKE_INSTALL_PREFIX \$ENV{prefix})
 


### PR DESCRIPTION
RISCV installs place the libraries inside a folder that is named after the ABI, so we need to prompt CMake to search there. This should fix the toolchain issue discussed in https://github.com/JuliaPackaging/Yggdrasil/pull/10922#discussion_r2029505751.

cc @eschnett @giordano 