### PR TITLE
Fix Meson build failures by separating macOS compile-time and link-time flags

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -455,10 +455,10 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         ])
 
         if Sys.isapple(p)
-            macos_version_flags = clang_use_lld ? (min_macos_version_flags()[1],) : min_macos_version_flags()
-            append!(flags, String[
-                macos_version_flags...,
-            ])
+             # Only add the compile-time flag here
+             append!(flags, String[
+                 min_macos_version_flags()[1],  # -mmacosx-version-min=...
+             ])
         end
 
         sanitize_compile_flags!(p, flags)
@@ -534,6 +534,12 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         if Sys.isapple(p)
             push!(flags, "-headerpad_max_install_names")
         end
+
+        if Sys.isapple(p) && !clang_use_lld
+            # Add the linker-specific flag only when linking
+            push!(flags, min_macos_version_flags()[2])  # -Wl,-sdk_version,...
+        end
+        
         return flags
     end
 


### PR DESCRIPTION
This is from PR that rebuilds Libepoxy https://github.com/JuliaPackaging/Yggdrasil/pull/11040 
```
# meson unconditionally (?) adds the command line argument
# `-Werror=unused-command-line-argument`. That would be fine, except
# that we (the `cc` script) add `-Wl,-sdk_version,11.0` on Darwin,
# which is actually unused when meson checks for supported compiler
# options. This means that each such check fails, and meson won't use
# any options. That's mostly fine, except for the option
# `-Wno-int-conversion` which is required by the source code.
#
# The code below modifies the `cc` script to filter out the option
# `-Werror=unused-command-line-argument`. This should arguably either
# happen by default, or `cc` should only add the
# `-Wl,-sdk_version,11.0` when the linker is actually called.
#
# We modify `cc` on all architectures to prevent possible similar
# errors there.
```

This fix was what I got from Claude. I haven't tested it locally. It may break things in unintended ways. 