### PR TITLE
Put default storage cache in a scratch space

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.40.0"
+version = "1.41.0"
 
 [deps]
 Bzip2_jll = "6e34b625-4abd-537c-b88f-471c36dfa7a0"

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,7 +1,0 @@
-# Ignore ccache
-/ccache
-
-# Ignore cached downloads
-/downloads
-
-/enable_apple

--- a/src/BinaryBuilderBase.jl
+++ b/src/BinaryBuilderBase.jl
@@ -176,7 +176,7 @@ function __init__()
 
     # Allow the user to override the default value for `storage_dir`
     storage_cache[] = get(ENV, "BINARYBUILDER_STORAGE_DIR",
-                          abspath(joinpath(@__DIR__, "..", "deps")))
+                          @get_scratch!("storage_cache"))
 
     # If the user has signalled that they really want us to automatically
     # accept apple EULAs, do that.


### PR DESCRIPTION
I've been wanting to make this change for years.  BinaryBuilder2 does already something along these lines: https://github.com/JuliaPackaging/BinaryBuilder2.jl/blob/8243bd31c94f542b44c254d9c729ad133cc990b0/BinaryBuilderSources.jl/src/BinaryBuilderSources.jl#L138-L140