### PR TITLE
[CI] Update `julia-actions/setup-julia` to v2

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/cache@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: "1.7"
       - uses: julia-actions/julia-docdeploy@releases/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,12 +87,12 @@ jobs:
     steps:
       - run: sudo rm -rf /opt/*
       - uses: actions/checkout@v5
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: x64
       # We can't cache artifacts at the moment, it'd require more than 10 GiB.
-      # - uses: julia-actions/cache@v1
+      # - uses: julia-actions/cache@v2
       #   # For the time being cache artifacts only for squashfs, we need too much
       #   # storage for the unpacked shards
       #   if: ${{ matrix.squashfs == true }}


### PR DESCRIPTION
I never understood why Dependabot didn't update it.