### PR TITLE
[Runner] Fix build id with lld on windows

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -440,9 +440,13 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
         # build-id is not supported on macOS compilers
         if !Sys.isapple(p)
             # Windows build-id requires binutils 2.25+, which we only have for GCC 5+
-            if !Sys.iswindows(p) || (Sys.iswindows(p) && gcc_version ≥ v"5")
+            if !Sys.iswindows(p) || (Sys.iswindows(p) && gcc_version ≥ v"5" && !clang_use_lld)
                 # Use a known algorithm to embed the build-id for reproducibility
                 push!(flags, "-Wl,--build-id=sha1")
+            elseif Sys.iswindows(p) && clang_use_lld
+                # This is reproducible as we set `-Wl,--no-insert-timestamp` elsewhere
+                # See https://github.com/llvm/llvm-project/issues/74238#issuecomment-1839640836
+                push!(flags, "-Wl,--build-id")
             end
         end
     end
@@ -550,6 +554,10 @@ function generate_compiler_wrappers!(platform::AbstractPlatform; bin_path::Abstr
                 # The `-sdk_version` flag is not implemented in lld yet.
                 append!(flags, min_macos_version_linker_flags())
             end
+        elseif Sys.iswindows(p) && gcc_version ≥ v"5"
+            # Do not embed timestamps, for reproducibility:
+            # https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/1232
+            push!(flags, "-Wl,--no-insert-timestamp")
         end
 
         buildid_link_flags!(p, flags)

--- a/test/runners.jl
+++ b/test/runners.jl
@@ -160,9 +160,9 @@ end
 
     # Checks that the compiler/linker include a build-id
     # This is only available on ELF-based platforms
-    @testset "Compilation - Linux build-id note $(platform) - $(compiler)" for platform in elf_platforms, compiler in ("cc", "gcc", "clang", "c++", "g++", "clang++")
+    @testset "Compilation - Linux build-id note $(platform) - $(compiler) - clang_use_lld=$(clang_use_lld)" for platform in elf_platforms, compiler in ("cc", "gcc", "clang", "c++", "g++", "clang++"), clang_use_lld in (true, false)
         mktempdir() do dir
-            ur = preferred_runner()(dir; platform=platform)
+            ur = preferred_runner()(dir; platform=platform, clang_use_lld=clang_use_lld)
             iobuff = IOBuffer()
             test_c = """
                 #include <stdlib.h>
@@ -196,10 +196,10 @@ end
     end
 
     # Checks that Windows can include a build-id
-    @testset "Compilation - Windows build-id note $(platform) - $(compiler)" for platform in win_platforms, compiler in ("cc", "gcc", "clang", "c++", "g++", "clang++")
+    @testset "Compilation - Windows build-id note $(platform) - $(compiler) - clang_use_lld=$(clang_use_lld)" for platform in win_platforms, compiler in ("cc", "gcc", "clang", "c++", "g++", "clang++"), clang_use_lld in (true, false)
         mktempdir() do dir
             # Windows build-id support requires binutils 2.25, which is part of our GCC 5
-            ur = preferred_runner()(dir; platform=platform, preferred_gcc_version=v"5")
+            ur = preferred_runner()(dir; platform=platform, preferred_gcc_version=v"5", clang_use_lld=clang_use_lld)
             iobuff = IOBuffer()
             test_c = """
                 #include <stdlib.h>


### PR DESCRIPTION
As discovered in https://github.com/JuliaPackaging/Yggdrasil/pull/12004, `--build-id=sha1` doesn't seem to be supported with lld on windows.
Also, to make reproducible set `-Wl,--no-insert-timestamp` when using clang (we already do this for gcc).