### PR TITLE
Rebuild LLVMBootstrap 19/20/21 (libxml2-free, mingw cpuid fix)

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -4070,69 +4070,69 @@ os = "linux"
 
 [["LLVMBootstrap.v19.1.7.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "aaa44500ab5a78e579d177a3fb5d471b30b8e69e"
+git-tree-sha1 = "ed30ba1ddef97c83b4bf4be50688b846f6492431"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["LLVMBootstrap.v19.1.7.x86_64-linux-musl.squashfs".download]]
-    sha256 = "e83a797da478f1942177310ba3f8d69cc9d988193a1cadad0ddcdf496cd6f7ec"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/LLVMBootstrap-v19.1.7/LLVMBootstrap.v19.1.7.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "f9f08703af5bc3b7f3609b6101d1be30518f3e5e6c162ad09af4eb5b6db8cee0"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/LLVMBootstrap-v19.1.7+0/LLVMBootstrap.v19.1.7.x86_64-linux-musl.squashfs.tar.gz"
 
 [["LLVMBootstrap.v19.1.7.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "7b30f44df4d78118cf6d6be609b44fec728d3dda"
+git-tree-sha1 = "031e9e5096f016fd10a71a85636bd98ade849baf"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["LLVMBootstrap.v19.1.7.x86_64-linux-musl.unpacked".download]]
-    sha256 = "d4ce4f112b3d1e169e4097e92a0421facc52b54cdc4ab58b01ac1849224d08cc"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/LLVMBootstrap-v19.1.7/LLVMBootstrap.v19.1.7.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "88c88066206c23e45179dc29344747f49436885d9629939822c89a25e703d7f0"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/LLVMBootstrap-v19.1.7+0/LLVMBootstrap.v19.1.7.x86_64-linux-musl.unpacked.tar.gz"
 
 [["LLVMBootstrap.v20.1.2.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "a79ffecaf61e3c330c86a300f696c0cec7b6f0b5"
+git-tree-sha1 = "8e6f20843ecda6cf73b9b8b766e1524231bb1781"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["LLVMBootstrap.v20.1.2.x86_64-linux-musl.squashfs".download]]
-    sha256 = "98c8f8f01c82c899be27a260c53133fadd92472df6bfcc3cfe4052bcd1ac3ad2"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/LLVMBootstrap-v20.1.2/LLVMBootstrap.v20.1.2.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "be1f78f5ca2327ca7710cecea5912cdba9660fad00e33049b9039aa41c25aebe"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/LLVMBootstrap-v20.1.2+0/LLVMBootstrap.v20.1.2.x86_64-linux-musl.squashfs.tar.gz"
 
 [["LLVMBootstrap.v20.1.2.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "cd6b263b5092cf49bec2a61d7bbe1054a795a318"
+git-tree-sha1 = "fa0ca3c8941dabf4504241882f896fb5ba1f94fb"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["LLVMBootstrap.v20.1.2.x86_64-linux-musl.unpacked".download]]
-    sha256 = "e96a9b82042bad6e97222b9603ce465650f04094a42eb7327621006b22735f35"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/LLVMBootstrap-v20.1.2/LLVMBootstrap.v20.1.2.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "d013967dc922c526a37fd524c863833f71df630cb38f46bace00b1a02ef9a6c6"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/LLVMBootstrap-v20.1.2+0/LLVMBootstrap.v20.1.2.x86_64-linux-musl.unpacked.tar.gz"
 
 [["LLVMBootstrap.v21.1.8.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "39e232ef8d22495a5451636f24730465a856b100"
+git-tree-sha1 = "2d54540e4cd7a5f1d964bc2bb3423c9e28301657"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["LLVMBootstrap.v21.1.8.x86_64-linux-musl.squashfs".download]]
-    sha256 = "61b0c8eda2f000d924a7d43337ae757e1370e9c5cd830a9018591a721aa9a646"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/LLVMBootstrap-v21.1.8/LLVMBootstrap.v21.1.8.x86_64-linux-musl.squashfs.tar.gz"
+    sha256 = "6dc12b11f509e25e7ba48ba595ce76711612bc5a20acf4f230bee44cea999873"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/LLVMBootstrap-v21.1.8+0/LLVMBootstrap.v21.1.8.x86_64-linux-musl.squashfs.tar.gz"
 
 [["LLVMBootstrap.v21.1.8.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "a2cebd79d115b6c76802e8739d05508c5fcc0e09"
+git-tree-sha1 = "3e459b76914b199246440eec72e19e822449b389"
 lazy = true
 libc = "musl"
 os = "linux"
 
     [["LLVMBootstrap.v21.1.8.x86_64-linux-musl.unpacked".download]]
-    sha256 = "74acf51ec2c61605fdd0f56cbf99b0f24b3b9196801a5299c52a995747de049d"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/LLVMBootstrap-v21.1.8/LLVMBootstrap.v21.1.8.x86_64-linux-musl.unpacked.tar.gz"
+    sha256 = "1a8ee5cd423f634fc091d22f03bfc794f0294a43b5bdbb233b813935ebfd9831"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/LLVMBootstrap-v21.1.8+0/LLVMBootstrap.v21.1.8.x86_64-linux-musl.unpacked.tar.gz"
 
 [["LLVMBootstrap.v6.0.1.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BinaryBuilderBase"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
-version = "1.45.0"
+version = "1.46.0"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Point the LLVMBootstrap 19.1.7/20.1.2/21.1.8 shards at rebuilt +0 releases from JuliaPackaging/Yggdrasil. The previous build bundled libxml2 2.14 into the target sysroot, which broke cross-compile links (libxml2 2.14 dropped symbol versioning, so libs built against older libxml2 like libhwloc failed to link); the rebuild is LLVM_ENABLE_LIBXML2=OFF and also carries a clang cpuid.h patch fixing __cpuidex on mingw. See https://github.com/JuliaPackaging/Yggdrasil/pull/14102.