### PR TITLE
Use dedicated gzip and zstd decompressors

### DIFF
--- a/src/ArchiveUtils.jl
+++ b/src/ArchiveUtils.jl
@@ -1,5 +1,5 @@
 using Base: SHA1
-using Downloads, Tar, p7zip_jll, pigz_jll, SimpleBufferStream, SHA
+using Downloads, Tar, p7zip_jll, pigz_jll, SimpleBufferStream, SHA, Zstd_jll
 using Pkg.Artifacts: artifact_exists, artifact_path, query_override
 using XZ_jll: xz
 
@@ -21,6 +21,25 @@ function detect_compressor(header::Vector)
     return nothing
 end
 
+"""
+    decompress_cmd(path, compressor) -> Cmd
+
+Build the command that decompresses `path` (already classified as `compressor`) to stdout.
+
+The command-returning JLL wrappers carry their environment in the `Cmd`, unlike the
+`do`-block wrappers that mutate process-global environment state.
+"""
+function decompress_cmd(path::AbstractString, compressor::AbstractString)
+    if compressor == "gzip"
+        return `$(pigz()) -dc $(path)`
+    elseif compressor == "zstd"
+        # The p7zip bundled with older Julia releases cannot decode zstd streams.
+        return `$(Zstd_jll.zstd()) -dc $(path)`
+    end
+    # p7zip handles everything else we know how to detect
+    return `$(p7zip()) e $(path) -so -t$(compressor)`
+end
+
 function decompress(path::AbstractString)
     # Read the first few bytes of data to classify it:
     compressor = open(path) do io
@@ -30,11 +49,8 @@ function decompress(path::AbstractString)
         error("Called decompress() on uncompressed file")
     end
 
-    p7zip() do p7z
-        # Launch p7zip as our decompressor engine, clueing it in to the compressor
-        p = open(`$p7z e $(path) -so -t$(compressor)`; read=true)
-        return p.out
-    end
+    p = open(decompress_cmd(path, compressor); read=true)
+    return p.out
 end
 
 # Many functions don't like `PipeEndpoint`, so we interface with a BufferStream

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -8,8 +8,10 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 ObjectFile = "d8793406-e978-5875-9003-1fc021f44a92"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+Zstd_jll = "3161d3a3-bdf6-5164-811a-617609db77b4"
 
 [compat]
 ConstructionBase = "1.5.1"

--- a/test/archive_utils.jl
+++ b/test/archive_utils.jl
@@ -1,7 +1,10 @@
-using BinaryBuilderBase: Prefix, archive_artifact, package, list_tarball_files, detect_compressor
+using BinaryBuilderBase: Prefix, archive_artifact, package, unpack, list_tarball_files, detect_compressor
 using Pkg.Artifacts: create_artifact, remove_artifact, with_artifacts_directory
+using Pkg.GitTools: tree_hash
 using SHA
+using Tar
 using Test
+using Zstd_jll
 
 @testset "Archive Utils" begin
     @testset "package" begin
@@ -87,6 +90,45 @@ using Test
             end
         end
 
+    end
+
+    @testset "unpack" begin
+        # Round-trip a tree through every compressor `detect_compressor` knows about, and
+        # check `unpack` reproduces it exactly.  `package` can only write gzip/xz/bzip2
+        # (p7zip has no zstd encoder), so the zstd tarball is built by hand.
+        mktempdir() do src_dir
+            mkpath(joinpath(src_dir, "bin"))
+            mkpath(joinpath(src_dir, "lib"))
+            write(joinpath(src_dir, "bin", "bar.sh"), "#!/bin/sh\necho yolo\n")
+            chmod(joinpath(src_dir, "bin", "bar.sh"), 0o755)
+            write(joinpath(src_dir, "lib", "libbaz.so.1.2.3"), "this is not an actual .so\n")
+            symlink("libbaz.so.1.2.3", joinpath(src_dir, "lib", "libbaz.so"))
+            reference = bytes2hex(tree_hash(src_dir))
+
+            for format in ("gzip", "xz", "zstd", "bzip2")
+                mktempdir() do output_dir
+                    tarball_path = joinpath(output_dir, "foo.tar")
+                    if format == "zstd"
+                        # Julia 1.7 does not reliably wait for this pipeline when Tar.create
+                        # writes to its stdin, which can leave a valid but empty zstd stream.
+                        uncompressed_path = joinpath(output_dir, "foo.uncompressed.tar")
+                        Tar.create(src_dir, uncompressed_path)
+                        run(`$(Zstd_jll.zstd()) -q -f -o $(tarball_path) $(uncompressed_path)`)
+                    else
+                        package(src_dir, tarball_path; format=format)
+                    end
+                    @test open(io -> detect_compressor(read(io, 6)), tarball_path) == format
+
+                    mktempdir() do dest_dir
+                        unpack(tarball_path, dest_dir)
+                        # Contents, permissions and symlinks must all survive
+                        @test bytes2hex(tree_hash(dest_dir)) == reference
+                        @test islink(joinpath(dest_dir, "lib", "libbaz.so"))
+                        @test filemode(joinpath(dest_dir, "bin", "bar.sh")) & 0o111 != 0
+                    end
+                end
+            end
+        end
     end
 
     @testset "Artifact archival" begin


### PR DESCRIPTION
Use `pigz_jll` for gzip decompression and `Zstd_jll` for zstd streams instead of routing both through p7zip.

The command-returning JLL wrappers carry their environment in the `Cmd`, avoiding the process-global environment mutation performed by the do-block wrappers. This makes `unpack` safe to call concurrently.

Using pigz also improves gzip decompression throughput. On 18 Clang_unified tarballs, unpacking decreased from 26.7 seconds to 18.8 seconds.

This work prompted by an excruciatingly slow registration of Clang_unified_jll on Yggdrasil.

Assisted by: Claude Fable 5, GPT 5.6 Sol